### PR TITLE
Add support for BTTV COVID-19 "event" emotes

### DIFF
--- a/src/ffzap-bttv/index.js
+++ b/src/ffzap-bttv/index.js
@@ -259,12 +259,8 @@ class BetterTTV extends Addon {
 			const nightSubEmotes = [];
 
 			const overlayEmotes = {
-				'SoSnowy': '2px 0 0 1px',
-				'CandyCane': null,
-				'ReinDeer': null,
-				'IceCold': '2px 0 0 1px',
-				'TopHat': null,
-				'SantaHat': null,
+				'cvMask': '3px 0 0 0',
+				'cvHazmat': '3px 0 0 0'
 			};
 
 			let i = emotes.length;
@@ -282,7 +278,7 @@ class BetterTTV extends Addon {
 					width: dataEmote.width,
 					height: dataEmote.height,
 					require_spaces: arbitraryEmote,
-					modifier: overlayEmotes.hasOwnProperty(dataEmote.code),
+					modifier: Object.prototype.hasOwnProperty.call(overlayEmotes, dataEmote.code),
 					modifier_offset: overlayEmotes[dataEmote.code],
 				};
 


### PR DESCRIPTION
Thanks to @MelonLord145 for getting the margins in his PR that he closed.

I'm not really the biggest fan of these emotes but people still enjoy them, so yeah.

Manual editing isn't optimal and I'm hoping that @night can add support for either a simple bool (`overlay: true` or similar) or perhaps full-on margins (Full emote-width works, I can do the math to get them positioned properly in FFZ) in the near future so that these and future emotes can be automatically supported.