### PR TITLE
New Account Highlighter 1.0.0

### DIFF
--- a/src/new-account-highlighter/index.js
+++ b/src/new-account-highlighter/index.js
@@ -1,0 +1,88 @@
+class NewAccountHighlighter extends Addon {
+	static Mappings = {};
+	updateTimer = null;
+
+	constructor(...args) {
+		super(...args);
+		this.inject('chat.actions');
+		this.inject('chat');
+
+		const NewAccountHighlights = {
+			type: 'newaccount_highlight',
+			priority: 95,
+		
+			process(tokens, msg, user) {
+				let minage = this.settings.get('newusers.minage');
+				let minuid = NewAccountHighlighter.Mappings[minage].uid;
+				if(msg.user.userID > minuid)
+				{
+					(msg.highlights = (msg.highlights || new Set())).add('user');
+					msg.mentioned = true;
+		
+					const color = this.settings.get('newusers.highlightcolor') || '#FFFFFF';
+					if(color)
+						msg.mention_color = color
+				}
+				return tokens;
+			}
+		}
+		this.chat.addTokenizer(NewAccountHighlights);
+	}
+
+	async refreshMappings() {
+		let url = 'https://ffz.0x.software/api/mappings.json';
+
+		return fetch(url).then((res) => {
+			return res.json()
+		}).then((out) => {
+			NewAccountHighlighter.Mappings = out;
+		}).catch(err => { throw err });
+	}
+
+	async onLoad() {
+		return this.refreshMappings();
+	}
+
+	onEnable() {
+		this.updateTimer = setInterval(() => {
+			this.refreshMappings();
+		}, (1000*60*25)+Math.floor(Math.random() * Math.floor(1000*60*10)));
+
+		var dataArray = [];
+		for (const key in NewAccountHighlighter.Mappings) {
+			dataArray.push({
+				value: key,
+				title: key
+			});
+		}
+		this.settings.add('newusers.minage', {
+			//default: "0",
+			ui: {
+				path: 'Add-Ons > New User Highlighter >> Highlights',
+				title: 'Minimum account age',
+				description: 'Users whose account is younger than the specified time will be highlighted in chat.',
+				component: 'setting-select-box',
+				data: dataArray,
+			},
+		});
+
+		this.settings.add("newusers.highlightcolor", {
+			ui: {
+				path: 'Add-Ons > New User Highlighter >> Highlights',
+				title: 'Highlight Color',
+				description: 'Set the color for your highlights',
+				component: 'setting-color-box',
+			},
+		});
+		
+	}
+
+	onDisable() {
+		clearInterval(this.updateTimer);
+	}
+
+	async onUnload() {
+	}
+}
+
+NewAccountHighlighter.register();

--- a/src/new-account-highlighter/index.js
+++ b/src/new-account-highlighter/index.js
@@ -4,7 +4,6 @@ class NewAccountHighlighter extends Addon {
 
 	constructor(...args) {
 		super(...args);
-		this.inject('chat.actions');
 		this.inject('chat');
 
 		const NewAccountHighlights = {
@@ -12,8 +11,9 @@ class NewAccountHighlighter extends Addon {
 			priority: 95,
 		
 			process(tokens, msg, user) {
-				let minage = this.settings.get('newusers.minage');
-				let minuid = NewAccountHighlighter.Mappings[minage].uid;
+				const minage = this.settings.get('newusers.minage');
+				const minagemapping = NewAccountHighlighter.Mappings[minage];
+				const minuid = minagemapping ? minagemapping.uid : Number.MAX_VALUE;
 				if(msg.user.userID > minuid)
 				{
 					(msg.highlights = (msg.highlights || new Set())).add('user');
@@ -30,7 +30,7 @@ class NewAccountHighlighter extends Addon {
 	}
 
 	async refreshMappings() {
-		let url = 'https://ffz.0x.software/api/mappings.json';
+		const url = 'https://ffz.0x.software/api/mappings.json';
 
 		return fetch(url).then((res) => {
 			return res.json()
@@ -56,7 +56,6 @@ class NewAccountHighlighter extends Addon {
 			});
 		}
 		this.settings.add('newusers.minage', {
-			//default: "0",
 			ui: {
 				path: 'Add-Ons > New User Highlighter >> Highlights',
 				title: 'Minimum account age',
@@ -67,6 +66,7 @@ class NewAccountHighlighter extends Addon {
 		});
 
 		this.settings.add("newusers.highlightcolor", {
+			default: '#FFFFFF',
 			ui: {
 				path: 'Add-Ons > New User Highlighter >> Highlights',
 				title: 'Highlight Color',

--- a/src/new-account-highlighter/manifest.json
+++ b/src/new-account-highlighter/manifest.json
@@ -1,0 +1,14 @@
+{
+    "enabled": true,
+    "requires": [],
+
+    "version": "1.0.0",
+    "icon": "https://i.imgur.com/2od9Ir6.png",
+
+    "short_name": "New Account Highlighter",
+    "name": "New Account Highlighter",
+    "author": "0x",
+    "description": "Highlights new user accounts in chat",
+
+    "settings": "add_ons.new_account_highlighter"
+}


### PR DESCRIPTION
This addon highlights new Twitch accounts that are newer than a specified age.