### PR TITLE
New Account Highlighter 1.0.2

### DIFF
--- a/src/new-account-highlighter/index.js
+++ b/src/new-account-highlighter/index.js
@@ -14,7 +14,9 @@ class NewAccountHighlighter extends Addon {
 				description: 'Users whose account is younger than the specified time will be highlighted in chat.',
 				component: 'setting-select-box',
 				data: () => {
-					return Object.keys(NewAccountHighlighter.Mappings).map(age => ({value: age, title: age}))
+					const arr = Object.keys(NewAccountHighlighter.Mappings).map(age => ({value: age, title: age}));
+					arr.push({value: null, title: "disabled"});
+					return arr;
 				}
 			}
 		});

--- a/src/new-account-highlighter/index.js
+++ b/src/new-account-highlighter/index.js
@@ -1,10 +1,33 @@
 class NewAccountHighlighter extends Addon {
-	static Mappings = {};
+	static Mappings = {"7d": 0};
 	updateTimer = null;
 
 	constructor(...args) {
 		super(...args);
 		this.inject('chat');
+
+		this.settings.add('newusers.minage', {
+			default: '7d',
+			ui: {
+				path: 'Add-Ons > New User Highlighter >> Highlights',
+				title: 'Minimum account age',
+				description: 'Users whose account is younger than the specified time will be highlighted in chat.',
+				component: 'setting-select-box',
+				data: () => {
+					return Object.keys(NewAccountHighlighter.Mappings).map(age => ({value: age, title: age}))
+				}
+			}
+		});
+
+		this.settings.add("newusers.highlightcolor", {
+			default: '#FFFFFF',
+			ui: {
+				path: 'Add-Ons > New User Highlighter >> Highlights',
+				title: 'Highlight Color',
+				description: 'Set the color for your highlights',
+				component: 'setting-color-box'
+			}
+		});
 
 		const NewAccountHighlights = {
 			type: 'newaccount_highlight',
@@ -47,34 +70,6 @@ class NewAccountHighlighter extends Addon {
 		this.updateTimer = setInterval(() => {
 			this.refreshMappings();
 		}, (1000*60*25)+Math.floor(Math.random() * Math.floor(1000*60*10)));
-
-		var dataArray = [];
-		for (const key in NewAccountHighlighter.Mappings) {
-			dataArray.push({
-				value: key,
-				title: key
-			});
-		}
-		this.settings.add('newusers.minage', {
-			ui: {
-				path: 'Add-Ons > New User Highlighter >> Highlights',
-				title: 'Minimum account age',
-				description: 'Users whose account is younger than the specified time will be highlighted in chat.',
-				component: 'setting-select-box',
-				data: dataArray,
-			},
-		});
-
-		this.settings.add("newusers.highlightcolor", {
-			default: '#FFFFFF',
-			ui: {
-				path: 'Add-Ons > New User Highlighter >> Highlights',
-				title: 'Highlight Color',
-				description: 'Set the color for your highlights',
-				component: 'setting-color-box',
-			},
-		});
-		
 	}
 
 	onDisable() {

--- a/src/new-account-highlighter/manifest.json
+++ b/src/new-account-highlighter/manifest.json
@@ -2,7 +2,7 @@
     "enabled": true,
     "requires": [],
 
-    "version": "1.0.1",
+    "version": "1.0.2",
     "icon": "https://i.imgur.com/2od9Ir6.png",
 
     "short_name": "New Account Highlighter",
@@ -10,5 +10,5 @@
     "author": "0x",
     "description": "Highlights new user accounts in chat",
 
-    "settings": "add_ons.new_account_highlighter"
+    "settings": "add_ons.new_user_highlighter"
 }


### PR DESCRIPTION
- moved adding settings to constructor
- provided a default value for the account age of 7 days
- changed initial empty mapping to an object that contains one (empty) mapping for the 7d default account age value
- refactored the way the select-box for minimum account age is generated
- changed manifest so pressing the "settings" button on the addons page now actually opens the addon's settings