### PR TITLE
New Account Highlighter 1.0.3

### DIFF
--- a/src/new-account-highlighter/index.js
+++ b/src/new-account-highlighter/index.js
@@ -55,7 +55,7 @@ class NewAccountHighlighter extends Addon {
 	}
 
 	async refreshMappings() {
-		const url = 'https://ffz.0x.software/api/mappings.json';
+		const url = 'https://ffz.0x.bot/api/mappings.json';
 
 		return fetch(url).then((res) => {
 			return res.json()

--- a/src/new-account-highlighter/manifest.json
+++ b/src/new-account-highlighter/manifest.json
@@ -2,7 +2,7 @@
     "enabled": true,
     "requires": [],
 
-    "version": "1.0.2",
+    "version": "1.0.3",
     "icon": "https://i.imgur.com/2od9Ir6.png",
 
     "short_name": "New Account Highlighter",


### PR DESCRIPTION
Changed the domain name for the timestamp->user-id API call because of internal reshuffling of resources.