### PR TITLE
Fix for mod keybinds.

### DIFF
--- a/src/smokemotes/index.jsx
+++ b/src/smokemotes/index.jsx
@@ -267,7 +267,7 @@ class SmokeysUtils extends Addon {
 
 		this.mod_keybind_handler();
 
-		this.ViewerCard.on('update', this.updateCard, this);
+		this.ViewerCard.on('mount', this.updateCard, this);
 		this.ViewerCard.on('unmount', this.unmountCard, this);
 	}
 

--- a/src/smokemotes/manifest.json
+++ b/src/smokemotes/manifest.json
@@ -2,7 +2,7 @@
 	"enabled": true,
 	"requires": [],
 	"icon": "https://i.imgur.com/WVFY4R5.png",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"short_name": "smokeys_utils",
 	"name": "Smokey's Utilities",
 	"author": "Smokey",
@@ -10,5 +10,5 @@
 	"website": "https://smokey.gg/",
 	"settings": "add_ons.smokemotes",
 	"created": "2019-12-08T01:03:54.000Z",
-	"updated": "2021-05-07T22:04:51.587Z"
+	"updated": "2021-05-07T22:05:24.511Z"
 }

--- a/src/smokemotes/manifest.json
+++ b/src/smokemotes/manifest.json
@@ -10,5 +10,5 @@
 	"website": "https://smokey.gg/",
 	"settings": "add_ons.smokemotes",
 	"created": "2019-12-08T01:03:54.000Z",
-	"updated": "2021-04-30T21:49:17.781Z"
+	"updated": "2021-05-07T22:04:51.587Z"
 }


### PR DESCRIPTION
Fixed: Use `mount` instead of `update` for viewer card information retrieval.