### PR TITLE
Fix issue with bttv pro emotes not always working

### DIFF
--- a/src/ffzap-bttv/index.js
+++ b/src/ffzap-bttv/index.js
@@ -145,7 +145,7 @@ class BetterTTV extends Addon {
 		if (user) {
 			const msg_user_id = msg.message.user.id;
 			if (user.id === msg_user_id) {
-				this.socket.broadcastMe(msg.channel);
+				this.socket.broadcastMe(`twitch:${msg.channelID}`);
 			}
 		}
 	}
@@ -376,7 +376,7 @@ class BetterTTV extends Addon {
 		this.emotes.unloadSet(realID);
 
 		if (this.chat.context.get('ffzap.betterttv.pro_emoticons')) {
-			this.socket.joinChannel(room.login);
+			this.socket.joinChannel(`twitch:${room.id}`);
 		}
 
 		if (!this.chat.context.get('ffzap.betterttv.channel_emoticons')) {

--- a/src/ffzap-bttv/manifest.json
+++ b/src/ffzap-bttv/manifest.json
@@ -8,7 +8,7 @@
 		"ffzap-core"
 	],
 	"icon": "https://cdn.betterttv.net/assets/logos/mascot.png",
-	"version": "3.2.8",
+	"version": "3.2.9",
 	"short_name": "FFZ:AP BTTV",
 	"name": "BetterTTV Emotes",
 	"author": "Lordmau5",

--- a/src/ffzap-bttv/manifest.json
+++ b/src/ffzap-bttv/manifest.json
@@ -16,5 +16,5 @@
 	"website": "https://ffzap.com/",
 	"settings": "add_ons.better_ttv_emotes",
 	"created": "2019-09-12T15:31:59.000Z",
-	"updated": "2021-09-05T21:32:47.553Z"
+	"updated": "2021-11-23T12:23:20.627Z"
 }


### PR DESCRIPTION
Fixes an issue with bttv pro/personal emotes sometimes not working in certain twitch channels. I believe this is casued due to the ffz addon using channel names instead of twitch:channelID in bttv's WS. Using the name works fine in most channels, but there seems to be an issue where if the channel has changed their name at some point, bttv ends up using the old channel name. 
I haven't been able to test this extensively but seems to work for me. It is the way bttv does it, so it should work.
Im pushing this to master instead of the bttv refactior as I don't know how close that is to completion. but could be a good idea to implement this change there aswell.