### PR TITLE
Chatterino Badges 1.0.0

### DIFF
--- a/src/chatterino-badges/index.js
+++ b/src/chatterino-badges/index.js
@@ -1,0 +1,73 @@
+class ChatterinoBadges extends Addon {
+	constructor(...args) {
+		super(...args);
+
+		this.inject('chat');
+		this.inject('chat.badges');
+		this.inject('settings');
+
+		this.badgeUrl = 'https://api.chatterino.com/badges';
+		this.maxBadgeId = -1;
+
+		this.settings.add('addon.chatterino_badges.badges', {
+			default: true,
+			ui: {
+				path: 'Add-Ons > Chatterino Badges >> Badges',
+				title: 'Enable Badges',
+				description: 'Show all available Chatterino user badges',
+				component: 'setting-check-box',
+			},
+			changed: () => this.updateBadges()
+		});
+	}
+
+	onEnable() {
+		this.updateBadges();
+	}
+
+	getIdFromIndex(index) {
+		return `addon.chatterino_badges.badge-${index}`;
+	}
+
+	async updateBadges() {
+		this.removeBadges();
+
+		if (this.settings.get('addon.chatterino_badges.badges')) {
+			const response = await fetch(this.badgeUrl);
+			const badgeData = await response.json();
+			const badges = badgeData.badges;
+			this.maxBadgeId = badges.length - 1;
+
+			for (let i = 0; i <= this.maxBadgeId; i++) {
+				const badge = badges[i];
+				const badgeId = this.getIdFromIndex(i);
+				this.badges.loadBadgeData(badgeId, {
+					id: `chatterino-${i}`,
+					title: badge.tooltip,
+					slot: 77,
+					image: badge.image1,
+					urls: {
+						1: badge.image1,
+						2: badge.image2,
+						4: badge.image3,
+					},
+					click_url: 'https://chatterino.com/',
+					svg: false,
+				});
+				this.badges.setBulk('addon.chatterino_badges', badgeId, badge.users);
+			}
+		}
+
+		this.emit('chat:update-lines');
+	}
+
+	removeBadges() {
+		for (let i = 0; i <= this.maxBadgeId; i++) {
+			this.badges.deleteBulk('addon.chatterino_badges', this.getIdFromIndex(i));
+		}
+
+		this.maxBadgeId = -1;
+	}
+}
+
+ChatterinoBadges.register();

--- a/src/chatterino-badges/manifest.json
+++ b/src/chatterino-badges/manifest.json
@@ -1,0 +1,17 @@
+{
+	"enabled": true,
+	"targets": [
+		"main",
+		"clips"
+	],
+	"requires": [],
+	"icon": "https://chatterino.com/logo.png",
+	"version": "1.0.0",
+	"short_name": "Chatterino",
+	"name": "Chatterino Badges",
+	"author": "Verotek",
+	"description": "Adds Chatterino Badges to your Chat Box.",
+	"settings": "add_ons.chatterino_badges",
+	"created": "2021-11-30T14:04:30.065Z",
+	"updated": "2021-11-30T14:04:30.065Z"
+}


### PR DESCRIPTION
I know this addon is not quite feature rich, but I believe that many people would also enjoy to see the badges within the native Twitch chat and since Chatterino also implements FFZ badges/emotes I think its a nice addition.
If this gets accepted still I would wait for the consent from Chatterino because the addon uses their API.