### PR TITLE
Add First Message Highlighter 1.0.0

### DIFF
--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -57,11 +57,13 @@ class FirstMessageHighlight extends Addon {
 
 	onEnable() {
 		this.chat.addTokenizer(this.messageHighlighter);
+		this.emit('chat:update-lines');
 	}
 
 	onDisable() {
 		this.chat.removeTokenizer(this.messageHighlighter);
 		this.known_users.clear();
+		this.emit('chat:update-lines');
 	}
 }
 

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -29,6 +29,8 @@ class FirstMessageHighlight extends Addon {
 			}
 		});
 
+		this.chat.addHighlightReason('first-message', "User's first message during this session");
+
 		let outerThis = this;
 
 		this.messageHighlighter = {

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -58,7 +58,7 @@ class FirstMessageHighlight extends Addon {
 	}
 
 	onEnable() {
-		if (ffz.site.getUser() != null)
+		if (ffz.site.getUser() !== null)
 			this.known_users.add(ffz.site.getUser().id);
 		this.chat.addTokenizer(this.messageHighlighter);
 		this.emit('chat:update-lines');

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -36,7 +36,7 @@ class FirstMessageHighlight extends Addon {
 			priority: 0,
 
 			process(tokens, msg) {
-				if (outerThis.known_users.has(msg.user.userID)) return tokens;
+				if (outerThis.known_users.has(msg.user.userID)) return;
 
 				outerThis.known_users.add(msg.user.userID);
 
@@ -47,7 +47,7 @@ class FirstMessageHighlight extends Addon {
 					'first-message'
 				);
 
-				return tokens;
+				return;
 			}
 		}
 	}
@@ -57,6 +57,7 @@ class FirstMessageHighlight extends Addon {
 	}
 
 	onDisable() {
+		this.chat.removeTokenizer(this.messageHighlighter);
 		this.known_users.clear();
 	}
 }

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -31,7 +31,7 @@ class FirstMessageHighlight extends Addon {
 
 		let outerThis = this;
 
-		const MessageHighlighter = {
+		this.messageHighlighter = {
 			type: 'message_highlighter',
 			priority: 0,
 
@@ -50,11 +50,10 @@ class FirstMessageHighlight extends Addon {
 				return tokens;
 			}
 		}
-
-		this.chat.addTokenizer(MessageHighlighter);
 	}
 
 	onEnable() {
+		this.chat.addTokenizer(this.messageHighlighter);
 	}
 
 	onDisable() {

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -58,6 +58,7 @@ class FirstMessageHighlight extends Addon {
 	}
 
 	onEnable() {
+		this.known_users.add(ffz.site.getUser().id);
 		this.chat.addTokenizer(this.messageHighlighter);
 		this.emit('chat:update-lines');
 	}

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -58,7 +58,8 @@ class FirstMessageHighlight extends Addon {
 	}
 
 	onEnable() {
-		this.known_users.add(ffz.site.getUser().id);
+		if (ffz.site.getUser() != null)
+			this.known_users.add(ffz.site.getUser().id);
 		this.chat.addTokenizer(this.messageHighlighter);
 		this.emit('chat:update-lines');
 	}

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -1,0 +1,72 @@
+class FirstMessageHighlight extends Addon {
+
+	known_users = [];
+
+	constructor(...args) {
+		super(...args);
+
+		this.inject('chat');
+
+		this.settings.add('first_message_highlight.priority', {
+			default: 0,
+			ui: {
+				path: 'Add-Ons > First Message Highlight >> Highlights',
+				title: 'Highlight Priority',
+				description: 'Priority of the highlight',
+				component: 'setting-text-box',
+				type: 'number',
+				process: 'to_int'
+			}
+		});
+
+		this.settings.add('first_message_highlight.highlight_color', {
+			default: '#3C1A1A',
+			ui: {
+				path: 'Add-Ons > First Message Highlight >> Highlights',
+				title: 'Highlight Color',
+				description: 'Highlight color to add to the message',
+				component: 'setting-color-box'
+			}
+		});
+
+		let outerThis = this;
+
+		const MessageHighlighter = {
+			type: 'message_highlighter',
+			priority: 0,
+
+			process(tokens, msg) {
+				if (outerThis.known_users.includes(msg.user.userID)) return tokens;
+
+				outerThis.known_users.push(msg.user.userID);
+
+				this.applyHighlight(
+					msg,
+					this.settings.get('first_message_highlight.priority'),
+					this.settings.get('first_message_highlight.highlight_color'),
+					'first-message'
+				);
+
+				return tokens;
+			}
+		}
+
+		this.chat.addTokenizer(MessageHighlighter);
+	}
+
+	onLoad() {
+	}
+
+	onEnable() {
+	}
+
+	onDisable() {
+		this.known_users = [];
+	}
+
+	async onUnload() {
+		this.known_users = [];
+	}
+}
+
+FirstMessageHighlight.register();

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -54,17 +54,10 @@ class FirstMessageHighlight extends Addon {
 		this.chat.addTokenizer(MessageHighlighter);
 	}
 
-	onLoad() {
-	}
-
 	onEnable() {
 	}
 
 	onDisable() {
-		this.known_users = [];
-	}
-
-	async onUnload() {
 		this.known_users = [];
 	}
 }

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -36,7 +36,10 @@ class FirstMessageHighlight extends Addon {
 			priority: 0,
 
 			process(tokens, msg) {
-				if (outerThis.known_users.has(msg.user.userID)) return;
+				if (msg.fh_known_user == null)
+					msg.fh_known_user = outerThis.known_users.has(msg.user.userID);
+
+				if (msg.fh_known_user) return;
 
 				outerThis.known_users.add(msg.user.userID);
 

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -1,6 +1,6 @@
 class FirstMessageHighlight extends Addon {
 
-	known_users = [];
+	known_users = new Set();
 
 	constructor(...args) {
 		super(...args);
@@ -36,9 +36,9 @@ class FirstMessageHighlight extends Addon {
 			priority: 0,
 
 			process(tokens, msg) {
-				if (outerThis.known_users.includes(msg.user.userID)) return tokens;
+				if (outerThis.known_users.has(msg.user.userID)) return tokens;
 
-				outerThis.known_users.push(msg.user.userID);
+				outerThis.known_users.add(msg.user.userID);
 
 				this.applyHighlight(
 					msg,
@@ -58,7 +58,7 @@ class FirstMessageHighlight extends Addon {
 	}
 
 	onDisable() {
-		this.known_users = [];
+		this.known_users.clear();
 	}
 }
 

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T22:05:29.712Z"
+	"updated": "2021-12-01T22:07:06.886Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T18:37:19.306Z"
+	"updated": "2021-12-01T18:38:01.979Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T22:07:06.886Z"
+	"updated": "2021-12-04T16:23:04.010Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T21:56:17.358Z"
+	"updated": "2021-12-01T22:03:59.413Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T18:57:33.051Z"
+	"updated": "2021-12-01T21:56:17.358Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T14:34:15.628Z"
+	"updated": "2021-12-01T18:37:19.306Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -1,0 +1,13 @@
+{
+	"enabled": true,
+	"requires": [],
+	"version": "1.0.0",
+	"icon": "https://i.imgur.com/Db2zP1l.png",
+	"short_name": "first_msg_highlight",
+	"name": "First Message Highlight",
+	"author": "deko_ration",
+	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
+	"settings": "add_ons.first_message_highlight",
+	"created": "2021-12-01T14:32:46.254Z",
+	"updated": "2021-12-01T14:34:15.628Z"
+}

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-04T16:23:04.010Z"
+	"updated": "2021-12-06T17:25:02.202Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T18:38:01.979Z"
+	"updated": "2021-12-01T18:57:33.051Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-01T22:03:59.413Z"
+	"updated": "2021-12-01T22:05:29.712Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-06T17:25:02.202Z"
+	"updated": "2021-12-06T17:26:54.327Z"
 }


### PR DESCRIPTION
Hello,

This add-on provides community-driven chats a way of identifying newcomers. Twitch already added a highlight for overall first-time chatters. However, this add-on expands that functionality by highlighting all users sending a message for the first time in the current session.

I've tried adhering to this repositories code-style as much as I could. I took inspiration from New Account Highlighter and Chat Repetition Detector. If any of either authors feel like I've copied their code, I'm happy to think of alternatives.

Please comment on any improvement opportunities or changes needed.