### PR TITLE
Replace deprecated String.prototype.substr() (#104) [skiplog]

### DIFF
--- a/src/example/index.js
+++ b/src/example/index.js
@@ -130,7 +130,7 @@ class Example extends Addon {
 			override_appearance(appearance, data, msg, current_room, current_user, mod_icons) {
 				if ( current_user ) {
 					appearance.type = 'text';
-					appearance.text = current_user.login.substr(0,2);
+					appearance.text = current_user.login.slice(0, 2);
 				}
 
 				return appearance;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but as the change is trivial it doesn't hurt to switch.