### PR TITLE
Add emoteless addon

### DIFF
--- a/src/emoteless/index.js
+++ b/src/emoteless/index.js
@@ -1,0 +1,55 @@
+class EmoteLessChat extends Addon {
+
+	constructor(...args) {
+		super(...args);
+
+		this.inject('chat');
+
+		this.settings.add('emote_less_chat.enabled', {
+			default: true,
+
+			ui: {
+				path: 'Add-Ons > Emote Less Chat >> Enabled',
+				title: 'Enable filter',
+				description: 'Removes every chat message, that only contains emotes',
+				component: 'setting-check-box',
+			},
+		});
+
+		this.messageFilter = {
+			type: 'emote_less_chat',
+			priority: 9,
+
+			process(tokens, msg) {
+				if (!this.context.get('emote_less_chat.enabled')) return tokens;
+
+				let SPACES = /^\s+$/g;
+				let emoteOnly = true;
+				for(const token of tokens) {
+					if (token.type === 'emote') continue;
+					if (token.type === 'text' && SPACES.test(token.text)) continue;
+					emoteOnly = false;
+					break;
+				}
+
+				if(emoteOnly == false) return tokens;
+
+				msg.ffz_removed = true;
+
+				return tokens;
+			}
+		}
+	}
+
+	onEnable() {
+		this.chat.addTokenizer(this.messageFilter);
+		this.emit('chat:update-lines');
+	}
+
+	onDisable() {
+		this.chat.removeTokenizer(this.messageFilter);
+		this.emit('chat:update-lines');
+	}
+}
+
+EmoteLessChat.register();

--- a/src/emoteless/manifest.json
+++ b/src/emoteless/manifest.json
@@ -1,0 +1,17 @@
+{
+    "enabled": true,
+    "requires": [],
+
+    "version": "1.0.5",
+    "icon": "https://echtkpvl.de/EchtkPvL-logo.png",
+
+    "short_name": "emote_less_chat",
+    "name": "Emote Less Chat",
+    "author": "EchtkPvL",
+    "description": "This addon removes every chat message, that only contains emotes.",
+
+    "website": "https://echtkpvl.de",
+    "settings": "add_ons.emote_less_chat",
+    "created": "2022-07-14T19:00:00.000Z",
+    "updated": "2022-07-19T07:35:01.337Z"
+}


### PR DESCRIPTION
This is an addon, that lets the user remove messages that don't contain any "usefull" information by filtering every message that only contains emotes. Especially for big streams this is an improvement for following the chat.