### PR TITLE
Add the "Hide Bits" Addon

### DIFF
--- a/src/hide-bits/index.js
+++ b/src/hide-bits/index.js
@@ -1,0 +1,5 @@
+const createElement = FrankerFaceZ.utilities.dom.createElement;
+
+var style = createElement("style");
+style.innerHTML = ".message .ffz-cheer {display: none}";
+document.head.append(style);

--- a/src/hide-bits/manifest.json
+++ b/src/hide-bits/manifest.json
@@ -1,0 +1,15 @@
+{
+  "enabled": true,
+  "unlisted": true,
+  "requires": [],
+
+  "version": "1.0.0",
+  "icon": "https://i.imgur.com/GzgzcF9.png",
+
+  "short_name": "hide-bits",
+  "name": "Hide Bits in Chat",
+  "author": "GabeDuarteM",
+  "description": "Hide the amount of bits in a chat message, especially useful to avoid spotting bit alerts that should be a surprise",
+
+  "website": "https://www.gabrielduarte.dev"
+}


### PR DESCRIPTION
The Addon hides the amount of bits in a chat message, leaving only the message, especially useful to avoid spotting bit alerts that should be a surprise.