### PR TITLE
First Message Highlight 1.0.1

### DIFF
--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -39,6 +39,16 @@ class FirstMessageHighlight extends Addon {
 			}
 		});
 
+		this.settings.add('first_message_highlight.only_moderated_channels', {
+			default: false,
+			ui: {
+				path: 'Add-Ons > First Message Highlight >> Settings',
+				title: 'Highlight only when moderating',
+				description: 'Only highlight messages in chats where you are a moderator.',
+				component: 'setting-check-box'
+			}
+		});
+
 		this.chat.addHighlightReason('first-message', "User's first message during this session");
 
 		const outerThis = this;
@@ -48,6 +58,9 @@ class FirstMessageHighlight extends Addon {
 			priority: 0,
 
 			process(tokens, msg) {
+				if (!outerThis.chat.context.get('context.moderator') 
+					&& this.settings.get('first_message_highlight.only_moderated_channels')) return;
+
 				if (msg.fh_known_user == null)
 					msg.fh_known_user = outerThis.known_users.has(msg.user.userID);
 

--- a/src/first-message-highlighter/index.js
+++ b/src/first-message-highlighter/index.js
@@ -29,9 +29,19 @@ class FirstMessageHighlight extends Addon {
 			}
 		});
 
+		this.settings.add('first_message_highlight.ignore_historical', {
+			default: false,
+			ui: {
+				path: 'Add-Ons > First Message Highlight >> Settings',
+				title: 'Ignore historical messages',
+				description: 'Do not highlight messages from before you joined the chat, but still remember the users.',
+				component: 'setting-check-box'
+			}
+		});
+
 		this.chat.addHighlightReason('first-message', "User's first message during this session");
 
-		let outerThis = this;
+		const outerThis = this;
 
 		this.messageHighlighter = {
 			type: 'message_highlighter',
@@ -44,6 +54,9 @@ class FirstMessageHighlight extends Addon {
 				if (msg.fh_known_user) return;
 
 				outerThis.known_users.add(msg.user.userID);
+
+				if (msg.isHistorical
+					&& this.settings.get('first_message_highlight.ignore_historical')) return;
 
 				this.applyHighlight(
 					msg,

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -1,7 +1,7 @@
 {
 	"enabled": true,
 	"requires": [],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"icon": "https://i.imgur.com/Db2zP1l.png",
 	"short_name": "first_msg_highlight",
 	"name": "First Message Highlight",
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2021-12-06T17:26:54.327Z"
+	"updated": "2023-03-07T20:50:23.675Z"
 }

--- a/src/first-message-highlighter/manifest.json
+++ b/src/first-message-highlighter/manifest.json
@@ -9,5 +9,5 @@
 	"description": "Addon to highlight the first message of a user during the current session. Useful for community-driven chats and welcoming.",
 	"settings": "add_ons.first_message_highlight",
 	"created": "2021-12-01T14:32:46.254Z",
-	"updated": "2023-03-07T20:50:23.675Z"
+	"updated": "2023-03-07T20:50:51.688Z"
 }


### PR DESCRIPTION
Adds two settings: 
 1. Ignoring historical messages (messages logged from before you joined) 
 2. Ignoring channels where you're not a moderator. Both are disabled by default.

Closes #111 