### PR TITLE
Adding back the space missing from FFZ:AP Core 3.3.9 refactoring of `remove_spaces` (#150) [skiplog]

### DIFF
--- a/src/ffzap-core/index.js
+++ b/src/ffzap-core/index.js
@@ -209,6 +209,7 @@ class FFZAP extends Addon {
 					
 					if (currentToken.type === 'text' && currentToken.text === ' ') {
 						if (lastToken?.type === 'emote' && nextToken?.type === 'emote') {
+							lastToken.text += ' ';
 							continue;
 						}
 					}


### PR DESCRIPTION
The `Remove Spaces Between Emotes` feature removes single spaces between emotes.
Previously, this space was then appended back to the 1st emote to keep message consistency

Last refactor removed this feature, so the copied text no long is in line with the actual received message:
![image](https://user-images.githubusercontent.com/101861126/224431226-b7dd2b28-59a5-4c76-a034-98379f21ee76.png)

(Creating a proper not-displaying spacing token might be better than altering the emotes alt texts, but I'd think that's a bit overkill for this feature)