### PR TITLE
Clip Confirm 1.0.2

### DIFF
--- a/src/clip-confirm/index.js
+++ b/src/clip-confirm/index.js
@@ -16,7 +16,6 @@ class ClipConfirm extends Addon {
 
 		this.settingsNamespace    = 'addon.clip-confirm';
 		this.rightControls        = document.querySelector( this.player.RIGHT_CONTROLS );
-		this.videoPlayerContainer = document.getElementsByClassName( 'video-player__container' )[0];
 		this.clipConfirmed        = false;
 		this.keyNames             = {
 			ctrl:  'Ctrl / ⌘',

--- a/src/clip-confirm/manifest.json
+++ b/src/clip-confirm/manifest.json
@@ -4,7 +4,7 @@
 		"main"
 	],
 	"requires": [],
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"short_name": "ClipConfirm",
 	"name": "Clip Confirm",
 	"author": "ArgoWizbang",
@@ -12,5 +12,5 @@
 	"website": "https://argowizbang.com/ffz-add-on/clip-confirm/",
 	"settings": "add_ons.clip_confirm",
 	"created": "2023-01-10T21:37:16.583Z",
-	"updated": "2023-01-18T04:20:37.595Z"
+	"updated": "2023-03-29T22:45:23.811Z"
 }

--- a/src/clip-confirm/manifest.json
+++ b/src/clip-confirm/manifest.json
@@ -12,5 +12,5 @@
 	"website": "https://argowizbang.com/ffz-add-on/clip-confirm/",
 	"settings": "add_ons.clip_confirm",
 	"created": "2023-01-10T21:37:16.583Z",
-	"updated": "2023-03-29T22:45:23.811Z"
+	"updated": "2023-03-29T22:53:19.023Z"
 }


### PR DESCRIPTION
* Fixed: Clip button's tooltip not updating to show the current "Skip Confirmation" Hotkey due to HTML changes in how Twitch handles button tooltips