### PR TITLE
fix: prattle-not chat spacing (fixes #153) (#159) [skiplog]

### DIFF
--- a/src/prattlenot/styles.scss
+++ b/src/prattlenot/styles.scss
@@ -13,6 +13,10 @@
 		height: 100%;
 		width: 100%;
 	}
+
+	& > div[tabindex="0"]:last-child {
+		height: auto;
+	}
 }
 
 .ffz-pn--list {


### PR DESCRIPTION
Fixes the issue by excluding the offending div from the height rule modifications done by PN.