### PR TITLE
Minor fix on ordered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ other assets.
 2.  Copy the `src/example` directory, making a new directory within `src` with
     the name of your add-on.
 3.  Edit your new `manifest.json` with details about your add-on.
-3.  Make sure you have node.js and pnpm set up and working.
-4.  Run `pnpm install` within the repository to install dependencies.
-5.  Run `pnpm start` to start the development server.
-6.  In the FrankerFaceZ Control Center, under Add-ons, make sure to enable the
+4.  Make sure you have node.js and pnpm set up and working.
+5.  Run `pnpm install` within the repository to install dependencies.
+6.  Run `pnpm start` to start the development server.
+7.  In the FrankerFaceZ Control Center, under Add-ons, make sure to enable the
     setting `Use Local Development Server`.
-7.  Ensure that your browser will accept the self-signed certificate issued by
+8.  Ensure that your browser will accept the self-signed certificate issued by
     the development server. You can visit https://localhost:8001/ with the
     development server running to see if it works.
-8.  Develop your add-on.
+9.  Develop your add-on.
     > **Note:** Changes made to your add-on's manifest will require that you
     > restart the development server to take effect.
-9.  When you're ready, set `enabled` to `true` in your add-on's manifest, then
+10.  When you're ready, set `enabled` to `true` in your add-on's manifest, then
     submit a pull request to bring your code into this repository's master branch.
-10. Once your code is accepted, the new add-on will automatically be built,
+11. Once your code is accepted, the new add-on will automatically be built,
     uploaded, and made available for end-users.
 
 ## Documentation


### PR DESCRIPTION
Just a minor fix on the README file to correct 2 consecutive numbers 3.

(This don't affect the output as MarkDown is smart enough to still produce a coherent ordered list, but this fix makes the render match what's on the file itself)