### PR TITLE
7tV - Fix badge tag regex to include the founder badge in the group as well

### DIFF
--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-03T19:18:24.273Z"
+	"updated": "2023-11-03T20:23:26.738Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -5,14 +5,14 @@
 		"main",
 		"clips"
 	],
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"short_name": "7TV",
 	"name": "7TV Emotes",
 	"author": "Melonify",
-	"maintainer": "Melonify, Lordmau5",
+	"maintainer": "Lordmau5",
 	"description": "Adds 7TV Channel & Global Emotes, Badges, and User Cosmetics.",
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-03T20:23:26.738Z"
+	"updated": "2023-11-03T20:24:20.414Z"
 }

--- a/src/7tv-emotes/modules/badges.js
+++ b/src/7tv-emotes/modules/badges.js
@@ -1,4 +1,4 @@
-const SUB_BADGE_REGEX = /sub\d+/;
+const SUB_BADGE_REGEX = /sub(?:\d+|founder)/;
 
 export default class Badges extends FrankerFaceZ.utilities.module.Module {
 	constructor(...args) {


### PR DESCRIPTION
Updates the sub badge regex to include `subfounder` as a valid Subscriber badge to properly group it in the Visibility page