### PR TITLE
7TV 1.4.2 Update

### DIFF
--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-04T23:36:03.054Z"
+	"updated": "2023-11-04T23:36:10.297Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-04T23:36:23.295Z"
+	"updated": "2023-11-04T23:36:30.793Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-04T23:36:10.297Z"
+	"updated": "2023-11-04T23:36:23.295Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-03T20:24:20.414Z"
+	"updated": "2023-11-04T23:35:26.833Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -5,7 +5,7 @@
 		"main",
 		"clips"
 	],
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"short_name": "7TV",
 	"name": "7TV Emotes",
 	"author": "Melonify",
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-04T23:36:30.793Z"
+	"updated": "2023-11-04T23:37:22.464Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-04T23:35:48.774Z"
+	"updated": "2023-11-04T23:36:03.054Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2023-11-04T23:35:26.833Z"
+	"updated": "2023-11-04T23:35:48.774Z"
 }

--- a/src/7tv-emotes/modules/avatars.js
+++ b/src/7tv-emotes/modules/avatars.js
@@ -13,51 +13,99 @@ export default class Avatars extends FrankerFaceZ.utilities.module.Module {
 			ui: {
 				path: 'Add-Ons > 7TV Emotes >> User Cosmetics',
 				title: 'Animated Avatars',
-				description: '**(Temporarily Unavailable, Coming Back Soon)**\n\nShow 7TV animated avatars on users who have them set. [(7TV Subscriber Perk)](https://7tv.app/subscribe)',
+				description: 'Show 7TV animated avatars on users who have them set. [(7TV Subscriber Perk)](https://7tv.app/subscribe)',
 				component: 'setting-check-box',
 			}
 		});
 
+		this.updateInterval = false;
+
 		this.userAvatars = new Map();
+
+		this.bufferedAvatars = [];
+		this.requestedAvatars = [];
 	}
 
 	async onEnable() {
-		// await this.findAvatarClass();
+		await this.findAvatarClass();
 
-		// this.on('settings:changed:addon.seventv_emotes.animated_avatars', () => this.updateAnimatedAvatars());
+		this.on('settings:changed:addon.seventv_emotes.animated_avatars', () => this.updateAvatarRenderer());
 
-		// this.updateAnimatedAvatars();
+		if (this.updateInterval) clearInterval(this.updateInterval);
+		this.updateInterval = setInterval(() => {
+			this.findAvatarImages();
+		}, 1000 * 3);
+
+		this.updateAvatarRenderer();
+	}
+	
+	receiveAvatarData(data) {		
+		if (!data.user?.username || !data.host?.files) return;
+		
+		const webpEmoteVersions = data.host.files.filter((value => value.format === 'WEBP'));
+		if (!webpEmoteVersions.length) return;
+		
+		const highestQuality = webpEmoteVersions[webpEmoteVersions.length - 1];
+		
+		this.userAvatars.set(data.user.username, `${data.host.url}/${highestQuality.name}`);
+
+		this.updateAvatarRenderer();
+	}
+
+	postAvatarRequests() {
+		if (!this.bufferedAvatars.length) return;
+		
+		const requestArray = [];
+		for (const login of this.bufferedAvatars) {
+			requestArray.push(`username:${login}`);
+
+			// Set their avatar to false already so it won't get requested again
+			this.userAvatars.set(login, false);
+		}
+		
+		const socket = this.resolve('..socket');
+		socket.emit({
+			op: socket.OPCODES.BRIDGE,
+			d: {
+				command: 'userstate',
+				body: {
+					identifiers: requestArray,
+					platform: 'TWITCH',
+					kinds: ['AVATAR']
+				}
+			}
+		});
+
+		this.bufferedAvatars = [];
+	}
+
+	findAvatarImages() {
+		this.rerenderAvatars();
+		this.postAvatarRequests();
 	}
 
 	async findAvatarClass() {
 		if (this.root.flavor != 'main') return;
 
 		const avatarElement = await this.site.awaitElement('.tw-avatar');
-
+		
 		if (avatarElement) {
 			const avatarComponent = this.fine.getOwner(avatarElement);
 
-			if (avatarComponent.type.displayName == 'ScAvatar') {
+			if (avatarComponent?.type?.styledComponentId?.includes('ScAvatar')) {
 				this.AvatarClass = avatarComponent.type;
 			}
 		}
 	}
 
-	getUserAvatar(login) {
-		return this.userAvatars.get(login.toLowerCase());
-	}
+	getUserAvatar(_login) {
+		const login = _login.toLowerCase();
 
-	async updateAnimatedAvatars() {
-		this.userAvatars.clear();
-
-		if (this.settings.get('addon.seventv_emotes.animated_avatars')) {
-			const avatars = await this.api.cosmetics.fetchAvatars();
-			for (const [login, avatar] of Object.entries(avatars)) {
-				this.userAvatars.set(login, avatar);
-			}
+		if (!this.userAvatars.has(login)) {
+			return undefined;
 		}
 
-		this.updateAvatarRenderer();
+		return this.userAvatars.get(login);
 	}
 
 	updateAvatarRenderer() {
@@ -88,8 +136,15 @@ export default class Avatars extends FrankerFaceZ.utilities.module.Module {
 	patchImageAvatar(component) {
 		const props = component.props;
 		if (props.userLogin && props['data-a-target'] != 'profile-image') {
-			const animatedAvatarURL = this.getUserAvatar(props.userLogin);
-			if (animatedAvatarURL) {
+			const login = props.userLogin.toLowerCase();
+
+			const animatedAvatarURL = this.getUserAvatar(login);
+			if (animatedAvatarURL === undefined) {
+				if (this.bufferedAvatars.includes(login)) return;
+
+				this.bufferedAvatars.push(login);
+			}
+			else if (animatedAvatarURL) {
 				props.SEVENTV_oldSrc = props.SEVENTV_oldSrc || props.src;
 				props.src = animatedAvatarURL;
 			}

--- a/src/7tv-emotes/modules/socket.js
+++ b/src/7tv-emotes/modules/socket.js
@@ -13,7 +13,8 @@ const OPCODES = {
 	RESUME: 34,
 	SUBSCRIBE: 35,
 	UNSUBSCRIBE: 36,
-	SIGNAL: 37
+	SIGNAL: 37,
+	BRIDGE: 38
 }
 
 export default class Socket extends FrankerFaceZ.utilities.module.Module {
@@ -29,6 +30,7 @@ export default class Socket extends FrankerFaceZ.utilities.module.Module {
 		this.injectAs('personal_emotes', '..personal-emotes');
 		this.injectAs('nametag_paints', '..nametag-paints');
 		this.injectAs('badges', '..badges');
+		this.injectAs('avatars', '..avatars');
 
 		this.settings.add('addon.seventv_emotes.update_messages', {
 			default: true,
@@ -39,6 +41,8 @@ export default class Socket extends FrankerFaceZ.utilities.module.Module {
 				component: 'setting-check-box',
 			}
 		});
+
+		this.OPCODES = OPCODES;
 
 		this.socket = false;
 		this._connected = false;
@@ -210,6 +214,9 @@ export default class Socket extends FrankerFaceZ.utilities.module.Module {
 				}
 				else if (kind === 'BADGE') {
 					this.badges.addBadge(data);
+				}
+				else if (kind === 'AVATAR') {
+					this.avatars.receiveAvatarData(data);
 				}
 			}
 			else if (type === 'entitlement.create') {


### PR DESCRIPTION
- Add support for animated avatars
- Add a checkbox back in for badge visibility
- Fix animated emotes not showing as static when the FFZ setting for animated emotes was set to `Disabled`
- Add tooltip to name paints
- Allow multiple personal sets for users (e.g. Personal Emotes and Event Emote Packs)