### PR TITLE
Clip Confirm 1.0.6

### DIFF
--- a/src/clip-confirm/index.js
+++ b/src/clip-confirm/index.js
@@ -71,7 +71,7 @@ class ClipConfirm extends Addon {
 			ui:      {
 				path:        'Add-Ons > Clip Confirm >> Behavior',
 				title:       '"Skip Confirmation" Hotkey',
-				description: 'Hotkey for skipping the clip confirmation when attempting to clip.\n\nIf you press/hold whatever combination of hotkeys you select here when you click the clip button (or use Twitch\'s built-in "Alt + X" shortcut) you will bypass the confirmation window entirely (so basically, the default behavior when this add-on is not installed). This makes it easier to make a clip when you know for a fact that you want to make a clip and don\'t require a confirmation.\n\nIf you do not select any hotkeys, this feature will be disabled.',
+				description: 'Hotkey for skipping the clip confirmation when attempting to clip.\n\nIf you press/hold whatever combination of hotkeys you select here when you click the clip button (or use Twitch\'s built-in "Alt + X" shortcut) you will bypass the confirmation window entirely (so basically, the default behavior when this add-on is not enabled). This makes it easier to make a clip when you know for a fact that you want to make a clip and don\'t require a confirmation.\n\nIf you do not select any hotkeys, this feature will be disabled.',
 				component:   'setting-select-box',
 				multiple:    true,
 				data:        [
@@ -216,7 +216,7 @@ class ClipConfirm extends Addon {
 			this.rightControlsObserver.observe( this.rightControls, { childList: true, subtree: true } );
 
 			/**
-			 * Twitch sometimes uses a different kind of tooltio that gets
+			 * Twitch sometimes uses a different kind of tooltip that gets
 			 * dynamically added/removed instead of the other tooltip they
 			 * use which keeps the tooltip's HTML always present on the
 			 * page, so we need this observer to check for that and update

--- a/src/clip-confirm/manifest.json
+++ b/src/clip-confirm/manifest.json
@@ -4,13 +4,13 @@
 		"main"
 	],
 	"requires": [],
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"short_name": "ClipConfirm",
 	"name": "Clip Confirm",
 	"author": "ArgoWizbang",
-	"description": "Adds a confirmation prompt (with optional manual bypass) to help prevent accidentally creating a clip when the Clip button is clicked.",
+	"description": "Adds a confirmation prompt (with optional manual bypass) when the Clip button is clicked.",
 	"website": "https://argowizbang.com/ffz-add-on/clip-confirm/",
 	"settings": "add_ons.clip_confirm",
 	"created": "2023-01-10T21:37:16.583Z",
-	"updated": "2023-08-27T18:02:52.711Z"
+	"updated": "2024-08-30T07:11:21.161Z"
 }


### PR DESCRIPTION
Just a few minor text updates/corrections including removing the mention of "accidentally creating a clip" from the add-on's description now that Twitch changed the default clip functionality to not actually publish a clip unless the user specifically clicks the "Publish" button.