### PR TITLE
Update: Trubbel’s Utilities 2.8.5

### DIFF
--- a/src/trubbel/manifest.json
+++ b/src/trubbel/manifest.json
@@ -10,9 +10,9 @@
 	"description": "Just some random things.",
 	"author": "Trubbel",
 	"maintainer": "Trubbel",
-	"version": "2.8.4",
+	"version": "2.8.5",
 	"search_terms": "trubbel",
 	"website": "https://twitch.tv/trubbel",
 	"created": "2025-01-06T23:29:54.496Z",
-	"updated": "2025-03-31T16:28:46.188Z"
+	"updated": "2025-04-10T23:41:51.945Z"
 }

--- a/src/trubbel/settings/chat-viewer-card.js
+++ b/src/trubbel/settings/chat-viewer-card.js
@@ -157,7 +157,7 @@ export class ChatViewerCard extends FrankerFaceZ.utilities.module.Module {
 
   checkNavigation() {
     if (!this.settings.get("addon.trubbel.chat.viewer-card")) return;
-    const chatRoutes = this.site.constructor.CHAT_ROUTES;
+    const chatRoutes = this.resolve("site").constructor.CHAT_ROUTES;
 
     if (chatRoutes.includes(this.router?.current?.name)) {
       this.init();

--- a/src/trubbel/settings/remove-things.js
+++ b/src/trubbel/settings/remove-things.js
@@ -2,7 +2,9 @@ const { ManagedStyle } = FrankerFaceZ.utilities.dom;
 const { has } = FrankerFaceZ.utilities.object;
 
 const CLASSES = {
+  "hide-stream-chat-header": ".stream-chat-header,.toggle-visibility__right-column--expanded",
   "hide-side-nav-for-you": ".side-nav--expanded [aria-label] :is(.side-nav__title):has(h2[class*=\"tw-title\"]:first-child)",
+  "hide-side-nav-sort-paragraph": "[data-a-target=\"side-nav-header-expanded\"] p",
   "hide-side-nav-guest-avatar": ".side-nav-card :is(.guest-star-avatar__mini-avatar)",
   "hide-side-nav-guest-number": ".side-nav-card [data-a-target=\"side-nav-card-metadata\"] :is(p):nth-child(2)",
   "hide-side-nav-hype-train": ".side-nav-card-hype-train-bottom",
@@ -23,6 +25,18 @@ export class RemoveThings extends FrankerFaceZ.utilities.module.Module {
     this.inject("settings");
     this.inject("site.router");
 
+    // Remove/Hide Things - Chat - Remove Stream Chat Header
+    this.settings.add("addon.trubbel.remove-things.chat-stream-chat-header", {
+      default: false,
+      ui: {
+        sort: 0,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Remove/Hide Things >> Chat",
+        title: "Remove Stream Chat Header",
+        description: "**Note:** This also hides the collapse and viewer list buttons.",
+        component: "setting-check-box"
+      },
+      changed: val => this.toggleHide("hide-stream-chat-header", val)
+    });
     // Remove/Hide Things - Left Navigation - Remove the "For You"-text
     this.settings.add("addon.trubbel.remove-things.left-nav-for-you", {
       default: false,
@@ -34,11 +48,22 @@ export class RemoveThings extends FrankerFaceZ.utilities.module.Module {
       },
       changed: val => this.toggleHide("hide-side-nav-for-you", val)
     });
+    // Remove/Hide Things - Left Navigation - Remove the "Viewers (High to Low)"-text
+    this.settings.add("addon.trubbel.remove-things.left-nav-sort-paragraph", {
+      default: false,
+      ui: {
+        sort: 1,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Remove/Hide Things >> Left Navigation",
+        title: "Remove the \"Viewers (High to Low)\"-text",
+        component: "setting-check-box"
+      },
+      changed: val => this.toggleHide("hide-side-nav-sort-paragraph", val)
+    });
     // Remove/Hide Things - Left Navigation - Remove the Guest avatars
     this.settings.add("addon.trubbel.remove-things.left-nav-guest-avatar", {
       default: false,
       ui: {
-        sort: 0,
+        sort: 2,
         path: "Add-Ons > Trubbel\u2019s Utilities > Remove/Hide Things >> Left Navigation",
         title: "Remove the Guest avatars",
         component: "setting-check-box"
@@ -49,7 +74,7 @@ export class RemoveThings extends FrankerFaceZ.utilities.module.Module {
     this.settings.add("addon.trubbel.remove-things.left-nav-guest-number", {
       default: false,
       ui: {
-        sort: 0,
+        sort: 3,
         path: "Add-Ons > Trubbel\u2019s Utilities > Remove/Hide Things >> Left Navigation",
         title: "Remove the Guest +number text",
         component: "setting-check-box"
@@ -60,7 +85,7 @@ export class RemoveThings extends FrankerFaceZ.utilities.module.Module {
     this.settings.add("addon.trubbel.remove-things.left-nav-hype-train", {
       default: false,
       ui: {
-        sort: 0,
+        sort: 4,
         path: "Add-Ons > Trubbel\u2019s Utilities > Remove/Hide Things >> Left Navigation",
         title: "Remove Hype Train",
         component: "setting-check-box"
@@ -180,7 +205,9 @@ export class RemoveThings extends FrankerFaceZ.utilities.module.Module {
   }
 
   onEnable() {
+    this.toggleHide("hide-stream-chat-header", this.settings.get("addon.trubbel.remove-things.chat-stream-chat-header"));
     this.toggleHide("hide-side-nav-for-you", this.settings.get("addon.trubbel.remove-things.left-nav-for-you"));
+    this.toggleHide("hide-side-nav-sort-paragraph", this.settings.get("addon.trubbel.remove-things.left-nav-sort-paragraph"));
     this.toggleHide("hide-side-nav-guest-avatar", this.settings.get("addon.trubbel.remove-things.left-nav-guest-avatar"));
     this.toggleHide("hide-side-nav-guest-number", this.settings.get("addon.trubbel.remove-things.left-nav-guest-number"));
     this.toggleHide("hide-side-nav-hype-train", this.settings.get("addon.trubbel.remove-things.left-nav-hype-train"));

--- a/src/trubbel/settings/sidebar.js
+++ b/src/trubbel/settings/sidebar.js
@@ -210,7 +210,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 10,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Tooltip Background",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });
@@ -222,7 +223,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 11,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Tooltip Title",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });
@@ -234,7 +236,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 12,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Tooltip Category",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });
@@ -246,7 +249,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 13,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Tooltip Viewer Count",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });
@@ -258,7 +262,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 14,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Tooltip Hype Train",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });
@@ -270,7 +275,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 15,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Tooltip Guests",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });
@@ -282,7 +288,8 @@ export class SideBarPreview extends FrankerFaceZ.utilities.module.Module {
         sort: 16,
         path: "Add-Ons > Trubbel\u2019s Utilities > Sidebar >> Left Navigation",
         title: "Border",
-        component: "setting-color-box"
+        component: "setting-color-box",
+				openUp: true
       },
       changed: () => this.updateCSS()
     });


### PR DESCRIPTION
* Added: Remove Stream Chat Header
* Added: Remove "Viewers (High to Low)"-text
* Fixed: Sidebar Channel Previews - the color picker should no longer be cut off
* Fixed: Viewer Cards for /mods and /vips - should now work correctly