### PR TITLE
Clips Manager Fullscreen Button 1.0.1

### DIFF
--- a/src/clips-manager-fullscreen-button/manifest.json
+++ b/src/clips-manager-fullscreen-button/manifest.json
@@ -1,12 +1,12 @@
 {
 	"enabled": true,
 	"requires": [],
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"short_name": "ClipsManagerFullscreenButton",
 	"name": "Clips Manager Fullscreen Button",
 	"author": "ArgoWizbang",
 	"description": "Adds a button to enable fullscreen mode to the video player on the Clips Manager page in the Creator Dashboard.",
 	"website": "https://argowizbang.com/ffz-add-on/clips-manager-fullscreen-button/",
 	"created": "2025-04-09T00:13:09.514Z",
-	"updated": "2025-04-09T00:13:09.514Z"
+	"updated": "2025-06-06T08:30:07.553Z"
 }

--- a/src/clips-manager-fullscreen-button/style.scss
+++ b/src/clips-manager-fullscreen-button/style.scss
@@ -1,3 +1,24 @@
+.ffz-cmfb-hide-cursor-and-controls {
+    cursor: none;
+
+    & .clips-player-background {
+        opacity: 0;
+    }
+}
+
+.clips-player-container.ffz-cmfb-fullscreen .clips-player-background {
+    background: none;
+}
+
+.clips-player-background > div {
+    z-index: var(--z-index-above);
+}
+
+.ffz-cmfb-fullscreen div:has(+ .ffz-cmfb-clips-player-right-controls) {
+    z-index: calc(var(--z-index-above) - 1);
+    background: linear-gradient(0deg, #000 0, rgba(0, 0, 0, 0.5) 60%, transparent);
+}
+
 .ffz-cmfb-clips-player-right-controls {
     position: absolute;
     bottom: 0 !important;


### PR DESCRIPTION
* Fixed: Reduced background gradient to only display under the player controls along the bottom of the player instead of over the entire video when in fullscreen
* Added: Hide cursor and player controls after 5 seconds of inactivity.