### PR TITLE
Update: Screenshotter 1.2.3

### DIFF
--- a/src/screenshotter/index.js
+++ b/src/screenshotter/index.js
@@ -183,12 +183,14 @@ class Screenshotter extends Addon {
 			{tip = (<div class="ffz-il-tooltip ffz-il-tooltip--align-right ffz-il-tooltip--up" role="tooltip" />)}
 		</div>)
 
-		const thing = container.querySelector('button[data-a-target="player-fullscreen-button"]')
-		if (thing) {
-			container.insertBefore(cont, thing.parentElement)
-		} else {
-			container.appendChild(cont)
-		}
+		let thing = container.querySelector('button[data-a-target="player-fullscreen-button"]')
+			while(thing?.parentElement && thing.parentElement !== container)
+				thing = thing.parentElement;
+
+			if ( thing?.parentElement === container )
+				container.insertBefore(cont, thing);
+			else
+				container.appendChild(cont);
 
 		let label = 'Take screenshot'
 

--- a/src/screenshotter/manifest.json
+++ b/src/screenshotter/manifest.json
@@ -1,7 +1,7 @@
 {
 	"enabled": true,
 	"requires": [],
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"short_name": "screenshotter",
 	"name": "Screenshotter",
 	"author": "CJMAXiK",
@@ -9,5 +9,5 @@
 	"description": "Allows you to take screenshots of the player using a button/shortcut.",
 	"settings": "add_ons.screenshotter",
 	"created": "2023-08-21T05:00:35.637Z",
-	"updated": "2024-08-13T13:03:22.618Z"
+	"updated": "2025-06-16T13:21:53.527Z"
 }


### PR DESCRIPTION
* Fixed: Screenshot button not appearing after Twitch's update.