### PR TITLE
Mass Moderation Utilities 2.1.0

### DIFF
--- a/src/mass-ban-tool/components/retrieving-recent-followers.jsx
+++ b/src/mass-ban-tool/components/retrieving-recent-followers.jsx
@@ -1,0 +1,35 @@
+const { createElement } = FrankerFaceZ.utilities.dom;
+
+export function retrievingRecentFollowers( fieldType ) {
+    let additionalInfo;
+
+    if ( fieldType === 'count' ) {
+        additionalInfo = (
+            <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stats`} class={`tw-border-l tw-mg-l-05 tw-pd-l-05 ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stats`}>
+                (<span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-current`} class={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType} ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-current`}></span> of <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-max`} class={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType} ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-max`}></span> completed)
+            </span>
+        );
+    } else {
+        additionalInfo = (
+            <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stats`} class={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stats`}>
+                <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-label-after`} class={`tw-border-l tw-mg-l-05 tw-pd-l-05 ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-label ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-label-after`}>After: <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-after`} class={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-after`}></span>
+                </span>
+                
+                <span id="ffz-mmu-mass-ban-tool-comma" class="ffz-mmu-mass-ban-tool-comma">, </span>
+                
+                <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-label-before`} class={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-label ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-label-before`}>Before: <span id={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-before`} class={`ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}-stat-before`}></span>
+                </span>
+            </span>
+        );
+    }
+
+    return (
+         <div class="tw-flex tw-align-items-start tw-pd-y-05 tw-mg-y-05 ffz-mmu-mass-ban-tool-recent-followers-loading">
+            <figure class="ffz-i-t-reset loading tw-mg-r-05"></figure>
+            Retrieving recent followers…
+            {
+                additionalInfo
+            }
+        </div>
+    );
+}

--- a/src/mass-ban-tool/features/ban-tool/index.jsx
+++ b/src/mass-ban-tool/features/ban-tool/index.jsx
@@ -1,6 +1,8 @@
 import { BUTTON_CLASS } from '../../utils/constants/css-classes';
 import { FILE_UPLOAD_BUTTON } from '../../components/file-upload-button';
-import { openFileSelector, addEntryToList, updateEntryCount } from '../../utils/entries-list.js';
+import { retrievingRecentFollowers } from '../../components/retrieving-recent-followers';
+import { isValidDate } from '../../utils/date.js';
+import { openFileSelector, addEntryToList, updateEntryCount, detectEnterKey } from '../../utils/entries-list.js';
 import GET_RECENT_FOLLOWERS from '../../utils/graphql/recent-followers.gql';
 
 const { createElement } = FrankerFaceZ.utilities.dom;
@@ -12,24 +14,19 @@ export class MassBanTool {
     }
 
     buildToolContent() {
-        const fileUploadButton = FILE_UPLOAD_BUTTON.cloneNode( true ),
+        const currentTime           = new Date(),
+              fileUploadButton      = FILE_UPLOAD_BUTTON.cloneNode( true ),
               recentFollowersImport = {
-                  five:       ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-5-followers-import'} onClick={ () => this.importRecentFollowers( 5 ) }><span class="tw-button__text">5</span></button> ),
-                  ten:        ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-10-followers-import'} onClick={ () => this.importRecentFollowers( 10 ) }><span class="tw-button__text">10</span></button> ),
-                  twentyFive: ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-25-followers-import'} onClick={ () => this.importRecentFollowers( 25 ) }><span class="tw-button__text">25</span></button> ),
-                  oneHundred: ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-100-followers-import'} onClick={ () => this.importRecentFollowers( 100 ) }><span class="tw-button__text">100</span></button> ),
+                  five:       ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-5-followers-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, 5 ) }><span class="tw-button__text">5</span></button> ),
+                  ten:        ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-10-followers-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, 10 ) }><span class="tw-button__text">10</span></button> ),
+                  twentyFive: ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-25-followers-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, 25 ) }><span class="tw-button__text">25</span></button> ),
+                  oneHundred: ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-100-followers-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, 100 ) }><span class="tw-button__text">100</span></button> ),
+                  fiveHundred: ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-500-followers-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, 500 ) }><span class="tw-button__text">500</span></button> ),
+                  oneThousand: ( <button type="button" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-1000-followers-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, 1000 ) }><span class="tw-button__text">1000</span></button> ),
                   custom:     ( <span class="tw-border-l tw-mg-l-1 tw-pd-l-1">
-                      <input type="number" id="ffz-mmu-mass-ban-tool-followers-import-custom-amount" name="ffz-mmu-mass-ban-tool-followers-import-custom-amount" class="tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-mg-05 ffz-input ffz-mmu-mass-ban-tool-followers-import-custom-amount" min="1" max="100" placeholder="Custom" onKeyUp={ ( event ) => {
-                                    if ( event.key === 'Enter' ) {
-                                        const value = parseInt( document.getElementById( 'ffz-mmu-mass-ban-tool-followers-import-custom-amount' ).value );
-
-                                        if ( ! isNaN( value ) ) {
-                                            this.importCustomFollowersAmount( value );
-                                        }
-                                    }
-                                } }/>
+                      <input type="number" id="ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount" name="ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount" class="tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-mg-05 ffz-input ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount" min="1" max="500" placeholder="Custom" data-field-type="count" onKeyUp={ ( e ) => detectEnterKey( this, e ) } />
         
-                      <button type="button" id="ffz-mmu-mass-ban-tool-custom-followers-import" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-custom-followers-import'} onClick={ () => this.importCustomFollowersAmount( parseInt( document.getElementById( 'ffz-mmu-mass-ban-tool-followers-import-custom-amount' ).value ) ) }>
+                      <button type="button" id="ffz-mmu-mass-ban-tool-custom-recent-followers-count-import" class={BUTTON_CLASS + ' ffz-mmu-mass-ban-tool-custom-recent-followers-count-import'} data-field-type="count" onClick={ ( e ) => this.importRecentFollowers( e, parseInt( document.getElementById( 'ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount' ).value ) ) }>
                                 <span class="tw-button__text">Import</span>
                       </button>
                   </span> )
@@ -40,7 +37,7 @@ export class MassBanTool {
                         <div class="tw-mg-y-05">
                             <div class="ffz--widget ffz--text-box default">
                                 <div class="tw-flex tw-align-items-center">
-                                    <label for="ffz-mmu-mass-ban-tool-entries-list">Users List<br /><span class="ffz-mmu-entry-count-label">(Current User Count: <span id="ffz-mmu-mass-ban-tool-entry-count" class="ffz-mmu-mass-ban-tool-entry-count ffz-mmu-entry-count" >0</span>)</span></label>
+                                    <label for="ffz-mmu-mass-ban-tool-entries-list">Users List<br /><span class="ffz-mmu-entry-count-label ffz-mmu-sub-label">(Count: <span id="ffz-mmu-mass-ban-tool-entry-count" class="ffz-mmu-mass-ban-tool-entry-count ffz-mmu-entry-count" >0</span>)</span></label>
 
                                     <textarea id="ffz-mmu-mass-ban-tool-entries-list" class="tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-mg-05 ffz-input ffz-mmu-mass-ban-tool-entries-list ffz-mmu-entries-list" placeholder="Username1&#10;Username2&#10;Username3&#10;Etc." rows="10" onKeyUp={ () => updateEntryCount( this.MMU, this ) }></textarea>
                                 </div>
@@ -69,19 +66,47 @@ export class MassBanTool {
 
                         <div class="tw-mg-y-05">
                             <div class="ffz--widget ffz--select-box">
-                                <div id="ffz-mmu-mass-ban-tool-recent-followers-field" class="tw-flex tw-align-items-start ffz-mmu-mass-ban-tool-recent-followers-field">
-                                    <label class="tw-mg-y-05" for="ffz-mmu-mass-ban-tool-recent-followers-import">Recent Followers</label>
+                                <div id="ffz-mmu-mass-ban-tool-recent-followers-count-field" class="tw-flex tw-align-items-start ffz-mmu-mass-ban-tool-recent-followers-count-field">
+                                    <label class="tw-mg-y-05" for="ffz-mmu-mass-ban-tool-recent-followers-count-import">Recent Followers<br /><span class="ffz-mmu-sub-label">(by count)</span></label>
 
-                                    <div class="tw-flex tw-align-items-start ffz-mmu-mass-ban-tool-recent-followers-inputs"></div>
+                                    <div class="tw-flex tw-mg-t-2 tw-align-items-start ffz-mmu-mass-ban-tool-recent-followers-count-inputs ffz-mmu-mass-ban-tool-recent-followers-inputs"></div>
 
-                                    <div class="tw-flex tw-align-items-start tw-pd-y-05 tw-mg-y-05 ffz-mmu-mass-ban-tool-recent-followers-loading">
-                                    <figure class="ffz-i-t-reset loading tw-mg-r-05"></figure> Retrieving recent followers&hellip;
-                                    </div>
+                                    { retrievingRecentFollowers( 'count' ) }
                                 </div>
 
                                 <section class="tw-c-text-alt-2">
                                     <div>
-                                        <p>Optionally you can automatically import a specific number of the most recent followers of the channel, up to 100.</p>
+                                        <p>Optionally you can automatically import a specific number of the most recent followers of the channel, up to 1000.</p>
+                                    </div>
+                                </section>
+                            </div>
+                        </div>
+
+                        <div class="tw-mg-y-05">
+                            <div class="ffz--widget ffz--select-box">
+                                <div id="ffz-mmu-mass-ban-tool-recent-followers-timestamp-field" class="tw-flex tw-align-items-start ffz-mmu-mass-ban-tool-recent-followers-timestamp-field">
+                                    <label class="tw-mg-y-05">Recent Followers<br /><span class="ffz-mmu-sub-label">(by follow time)</span></label>
+
+                                    <div class="tw-mg-t-2 ffz-mmu-mass-ban-tool-recent-followers-timestamp-inputs ffz-mmu-mass-ban-tool-recent-followers-inputs">
+
+                                        <label class="tw-font-size-7 tw-mg-l-05" for="ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-after-value">After:</label>
+
+                                        <input id="ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-after-value" class="tw-border-radius-medium tw-font-size-6 tw-pd-y-05 tw-mg-05 ffz-input ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-after-value" type="datetime-local" data-field-type="timestamp" onKeyUp={ ( e ) => detectEnterKey( this, e ) } />
+
+                                        <label class="tw-pd-l-1 tw-font-size-7" for="ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-before-value" value={currentTime}>Before:</label>
+
+                                        <input id="ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-before-value" class="tw-border-radius-medium tw-font-size-6 tw-pd-y-05 tw-mg-05 ffz-input ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-before-value" type="datetime-local" data-field-type="timestamp" onKeyUp={ ( e ) => detectEnterKey( this, e ) } />
+
+                                        <button type="button" id="ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-button" class="tw-pd-x-1 tw-pd-y-05 tw-mg-y-05 tw-mg-l-05 tw-border-bottom-left-radius-medium tw-border-bottom-right-radius-medium tw-button ffz-mmu-mass-ban-tool-custom-recent-followers-timestamp-import-button" data-field-type="timestamp" onClick={ ( e ) => this.importRecentFollowers( e ) }><span class="tw-button__text">Import</span></button>
+                                    </div>
+
+                                    
+                                    { retrievingRecentFollowers( 'timestamp' ) }
+                                </div>
+
+                                <section class="tw-c-text-alt-2">
+                                    <div>
+                                        <p>Optionally you can automatically import all followers within a specific time range, up to 72 hours in the past. These times should be based on <strong>*your*</strong> timezone. The "Before" field is optional and will be ignored if invalid (not fully selected).</p>
                                     </div>
                                 </section>
                             </div>
@@ -92,7 +117,7 @@ export class MassBanTool {
                                 <div class="tw-flex tw-align-items-center">
                                     <label class="tw-mg-y-05 action-label" for="ffz-mmu-mass-ban-tool-unban-action">Action To Take</label>
 
-                                    <select id="ffz-mmu-mass-ban-tool-unban-action" class="tw-border-radius-medium tw-font-size-6 ffz-select tw-pd-l-1 tw-pd-r-3 tw-pd-y-05 tw-mg-05 ffz-mmu-mass-ban-tool-action" onChange={ ( event ) => this.toggleBanReasonField( event ) }>
+                                    <select id="ffz-mmu-mass-ban-tool-unban-action" class="tw-border-radius-medium tw-font-size-6 ffz-select tw-pd-l-1 tw-pd-r-3 tw-pd-y-05 tw-mg-05 ffz-mmu-mass-ban-tool-action" onChange={ ( e ) => this.toggleBanReasonField( e ) }>
                                         <option value="ban">Ban</option>
 
                                         <option value="unban">Unban</option>
@@ -130,7 +155,7 @@ export class MassBanTool {
                 this.toolContent.querySelector( '.ffz-mmu-mass-ban-tool-upload-field' ).append( fileUploadButton );
         
                 for ( const importCount in recentFollowersImport ) {
-                    this.toolContent.querySelector( '.ffz-mmu-mass-ban-tool-recent-followers-inputs' ).append( recentFollowersImport[ importCount ] );
+                    this.toolContent.querySelector( '.ffz-mmu-mass-ban-tool-recent-followers-count-inputs' ).append( recentFollowersImport[ importCount ] );
                 }
                 
                 this.entriesListTextArea = this.toolContent.querySelector( '.ffz-mmu-mass-ban-tool-entries-list' );
@@ -138,50 +163,167 @@ export class MassBanTool {
                 return this.toolContent;
     }
 
-    async importRecentFollowers( count ) {
-        if ( count !== 0 && ! count ) {
+    getRecentFollowers( channelName, count, cursor ) {
+        return this.MMU.apollo.client.query( {
+                query: GET_RECENT_FOLLOWERS,
+                variables: {
+                    login: channelName,
+                    first: count,
+                    after: cursor
+                }
+        } )
+    }
+
+    async importRecentFollowers( event, count ) {
+        const fieldType   = event.target.dataset.fieldType,
+              customCount = {
+                  value:  document.getElementById( 'ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount' ),
+                  button: document.getElementById( 'ffz-mmu-mass-ban-tool-custom-recent-followers-count-import' )
+              }
+
+        let afterTime, beforeTime, currentDate, timeLimit, selectedTime,
+            stats         = {},
+            followersList = [];
+
+        if ( fieldType === 'count' && count !== 0 && ! count ) {
             return;
         }
 
-		if ( count >= 1 && count <= 100 ) {
-			this.toggleLoadingFollowers();
+        if ( fieldType === 'timestamp' ) {
+            afterTime  = document.getElementById( 'ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-after-value' ),
+            beforeTime = document.getElementById( 'ffz-mmu-mass-ban-tool-recent-followers-timestamp-import-before-value' ),
+            currentDate  = new Date(),
+            timeLimit    = new Date( currentDate.getTime() - 72 * 60 * 60 * 1000 ),
+            selectedTime = {
+                before: new Date( beforeTime.value ),
+                after:  new Date( afterTime.value )
+            };
 
-			try {
-				if ( ! this.MMU.apollo ) {
-                    this.toggleLoadingFollowers();
-                    return;
-				}
+            if ( ! isValidDate( selectedTime.after ) ) {
+                selectedTime.after = null;
+            }
 
-				const followers = await this.MMU.apollo.client.query( {
-						query: GET_RECENT_FOLLOWERS,
-						variables: {
-							login: this.MMU.channelName,
-							first: count
-						}
-				} )
+            if ( ! isValidDate( selectedTime.before ) ) {
+                selectedTime.before = null;
+            }
 
-				for ( const follower of followers?.data?.user?.followers?.edges ) {
-					addEntryToList( this.MMU, this, follower.node.displayName );
-				}
-			} catch {
-                this.toggleLoadingFollowers();
+            if ( selectedTime.before > currentDate ) {
+                selectedTime.before.setTime( currentDate );
+            }
+
+            stats.first  = selectedTime.after.toLocaleString();
+            stats.second = selectedTime.before.toLocaleString();
+        }
+
+        switch ( true ) {
+            case fieldType === 'count' && ! ( count >= 1 && count <= 1000 ):
+                alert( 'Number of recent followers to import must be between 1 and 1000.' );
+                return;
+
+            case fieldType === 'timestamp' && ( selectedTime.after === null && selectedTime?.before === null ):
+                alert( 'At least one follow time must be selected.' );
+                return;
+
+            case fieldType === 'timestamp' && ( selectedTime?.after !== null && selectedTime?.after < timeLimit ):
+                alert( '"After" follow time cannot be more than 72 hours before current time.' );
+                return;
+
+            case fieldType === 'timestamp' && ( selectedTime?.before !== null && selectedTime?.before < timeLimit ):
+                alert( '"Before" follow time cannot be more than 72 hours before current time.' );
+                return;
+
+            case fieldType === 'timestamp' && ( selectedTime?.after && selectedTime?.after > currentDate ):
+                alert( '"After" follow time cannot be in the future.' );
+                return;
+
+            case fieldType === 'timestamp' && ( selectedTime?.before !== null && selectedTime?.after !== null && selectedTime?.before < selectedTime?.after ):
+                alert( '"Before" follow time cannot be set to a time that comes before the "After" follow time.' );
+                return;
+        }
+
+        if ( fieldType === 'count' && ( event.target === customCount.value || event.target === customCount.button ) ) {
+            customCount.value.value = '';
+        } else if ( fieldType === 'timestamp' ) {
+            afterTime.value  = '';
+            beforeTime.value = '';
+        }
+
+        try {
+            if ( ! this.MMU.apollo ) {
                 return;
             }
 
-			this.toggleLoadingFollowers();
-		} else {
-			alert( 'Number of recent followers to import must be between 1 and 100.' );
-		}
+            let gqlCursor, gqlCount;
+
+            if ( fieldType === 'count' ) {
+                stats.first = 0;
+                stats.second = count;
+            }
+
+            this.updateStats( fieldType, stats );
+
+            this.toggleLoadingFollowers( fieldType );
+
+            do {
+                gqlCount = count;
+
+                if ( fieldType === 'timestamp' || count > 100 ) {
+                    gqlCount = 100;
+                }
+
+                const followers = await this.getRecentFollowers( this.MMU.channelName, gqlCount, gqlCursor );
+
+                for ( const follower of followers?.data?.user?.followers?.edges ) {
+                    let followedAt = new Date ( follower.followedAt );
+
+                    // Before time not working? Always selecting all 100
+                    if ( fieldType === 'timestamp' && ( ( selectedTime.after !== null && followedAt < selectedTime.after ) || ( selectedTime.before !== null && followedAt > selectedTime.before ) ) || followersList.includes( follower.node.displayName ) ) {
+                        count = gqlCount;
+                        break;
+                    }
+
+                    addEntryToList( this.MMU, this, follower.node.displayName );
+
+                    followersList.push( follower.node.displayName );
+
+                    gqlCursor = follower.cursor;
+                }
+
+                count = count - gqlCount;
+
+                if ( fieldType === 'count' ) {
+                    stats.first += gqlCount;
+
+                    this.updateStats( fieldType, stats )
+                }
+            } while ( count > 0 );
+        } catch {
+            this.toggleLoadingFollowers( fieldType );
+            return;
+        }
+
+        this.toggleLoadingFollowers( fieldType );
 	}
 
-    importCustomFollowersAmount( count ) {
-		document.getElementById( 'ffz-mmu-mass-ban-tool-followers-import-custom-amount' ).value = '';
+    updateStats( fieldType, stats ) {
+        let stat1, stat2;
 
-		this.importRecentFollowers( count );
-	}
+        const idPrefix = `ffz-mmu-mass-ban-tool-recent-followers-retrieving-${fieldType}`;
 
-    toggleLoadingFollowers() {
-		document.getElementById( 'ffz-mmu-mass-ban-tool-recent-followers-field' ).classList.toggle( 'loading' );
+        if ( fieldType === 'count' ) {
+            stat1 = document.getElementById( idPrefix + '-current' );
+            stat2 = document.getElementById( idPrefix + '-max' );
+        } else if ( fieldType === 'timestamp' ) {
+            stat1 = document.getElementById( idPrefix + '-stat-after' );
+            stat2 = document.getElementById( idPrefix + '-stat-before' );
+        }
+
+        stat1.textContent = stats.first;
+        stat2.textContent = stats.second;
+    }
+
+    toggleLoadingFollowers( fieldType ) {
+		document.getElementById( `ffz-mmu-mass-ban-tool-recent-followers-${fieldType}-field` ).classList.toggle( 'loading' );
 	}
 
     toggleBanReasonField( event ) {

--- a/src/mass-ban-tool/features/term-blocker/index.jsx
+++ b/src/mass-ban-tool/features/term-blocker/index.jsx
@@ -17,7 +17,7 @@ export class MassTermBlocker {
                 <div class="tw-mg-y-05">
                     <div class="ffz--widget ffz--text-box default">
                         <div class="tw-flex tw-align-items-center">
-                            <label for="ffz-mmu-mass-term-blocker-tool-entries-list">Terms List<br /><span class="ffz-mmu-entry-count-label">(Current Term Count: <span id="ffz-mmu-mass-term-blocker-tool-entry-count" class="ffz-mmu-mass-term-blocker-tool-entry-count ffz-mmu-entry-count" >0</span>)</span></label>
+                            <label for="ffz-mmu-mass-term-blocker-tool-entries-list">Terms List<br /><span class="ffz-mmu-entry-count-label">(Count: <span id="ffz-mmu-mass-term-blocker-tool-entry-count" class="ffz-mmu-mass-term-blocker-tool-entry-count ffz-mmu-entry-count" >0</span>)</span></label>
 
                             <textarea id="ffz-mmu-mass-term-blocker-tool-entries-list" class="tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-mg-05 ffz-input ffz-mmu-mass-term-blocker-tool-entries-list ffz-mmu-entries-list" placeholder="Term1&#10;Term2&#10;Term3&#10;Etc." rows="10" onKeyUp={ () => updateEntryCount( this.MMU, this ) }></textarea>
                         </div>
@@ -62,7 +62,7 @@ export class MassTermBlocker {
                             <div>
                                 <p>Select the privacy of the blocked term(s). This setting only applies if you are the streamer/channel owner; moderators are only able to create public blocked terms and setting this to "Private" will cause the mass term blocking to fail.</p>
 
-                                <p><b>NOTE:</b> Due to the nature of private term/phrase blocking, privately-blocked terms/phrases will not display any kind of confirmation of successful blocking such as a toast notification on the page or and entry in the Mod Actions log. You will need to check your <a href="https://dashboard.twitch.tv/settings/moderation/blocked-terms">Blocked Terms And Phrases</a> in your creator dashboard if you wish to confirm that they have been successfully blocked.</p>
+                                <p><b>NOTE:</b> Due to the nature of private term/phrase blocking, privately-blocked terms/phrases will not display any kind of confirmation of successful blocking such as a toast notification on the page or an entry in the Mod Actions log. You will need to check your <a href="https://dashboard.twitch.tv/settings/moderation/blocked-terms">Blocked Terms And Phrases</a> in your creator dashboard if you wish to confirm that they have been successfully blocked.</p>
                             </div>
                         </section>
                     </div>

--- a/src/mass-ban-tool/manifest.json
+++ b/src/mass-ban-tool/manifest.json
@@ -1,12 +1,12 @@
 {
 	"enabled": true,
 	"requires": [],
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"short_name": "MassModUtils",
 	"name": "Mass Moderation Utilities",
 	"author": "ArgoWizbang",
 	"description": "A tool for mass banning/unbanning users or blocking terms/phrases via mod view in channels that you moderate or own.\n\nThe button to open the tool can be found in the mod dock on the bottom left section of the mod view page.",
 	"website": "https://argowizbang.com/ffz-add-on/mass-ban-tool/",
 	"created": "2025-01-31T05:34:58.994Z",
-	"updated": "2025-05-01T02:46:36.388Z"
+	"updated": "2025-07-05T21:18:02.816Z"
 }

--- a/src/mass-ban-tool/style.scss
+++ b/src/mass-ban-tool/style.scss
@@ -1,6 +1,6 @@
 .ffz-mmu-modal.ffz-dialog {
     --width: min(40vw, 128rem);
-    --height: min(90vh, calc(0.9 * var(--width)));
+    --height: min(100vh, calc(0.9 * var(--width)));
 
     & header {
         cursor: initial;
@@ -14,7 +14,7 @@
         display: block;
     }
 
-    & .ffz-mmu-mass-ban-tool-followers-import-custom-amount {
+    & .ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount {
         min-width: 7.5rem;
         text-align: center;
     }
@@ -62,7 +62,13 @@
     }
 }
 
-.ffz-mmu-entry-count-label {
+.ffz-mmu-modal .ffz--widget label {
+    min-width: 8rem;
+    max-width: 10rem;
+    padding-right: 0.5rem;
+}
+
+.ffz-mmu-sub-label {
     font-size: 1.15rem;
 }
 
@@ -70,13 +76,28 @@
     font-weight: bold;
 }
 
-.ffz-mmu-mass-ban-tool-custom-followers-import {
-    margin-top: calc(0.5rem + var(--input-border-width-default) * -1) !important;
+.ffz-mmu-modal .tw-button__text {
+    pointer-events: none;
+}
+
+.ffz-mmu-mass-ban-tool-custom-recent-followers-count-import,
+.ffz-mmu-mass-ban-tool-custom-recent-followers-timestamp-import-button {
+    margin-top: calc(0.25rem + var(--input-border-width-default) * -1) !important;
+}
+
+.ffz-mmu-mass-ban-tool-recent-followers-timestamp-inputs .ffz-input {
+    padding-left: 0.35rem;
+    padding-right: 0.35rem;
 }
 
 .loading .ffz-mmu-mass-ban-tool-recent-followers-inputs,
 :not(.loading) > .ffz-mmu-mass-ban-tool-recent-followers-loading {
     display: none !important;
+}
+
+.loading.ffz-mmu-mass-ban-tool-recent-followers-count-field,
+.loading.ffz-mmu-mass-ban-tool-recent-followers-timestamp-field {
+    align-items: center !important;
 }
 
 .ffz--widget:has(.ffz-mmu-mass-ban-tool-ban-reason:disabled) .tw-flex:hover {
@@ -85,7 +106,6 @@
 
 .loading .ffz-mmu-mass-ban-tool-recent-followers-loading {
     display: flex !important;
-    line-height: 2rem;
     color: var(--color-background-button-primary-default);
 }
 

--- a/src/mass-ban-tool/utils/date.js
+++ b/src/mass-ban-tool/utils/date.js
@@ -1,0 +1,3 @@
+export function isValidDate( dateObj ) {
+    return dateObj instanceof Date && ! isNaN( dateObj );
+}

--- a/src/mass-ban-tool/utils/entries-list.js
+++ b/src/mass-ban-tool/utils/entries-list.js
@@ -34,3 +34,21 @@ export function addEntryToList( MMU, tool, user ) {
 export function updateEntryCount( MMU, tool ) {
     MMU.modal.querySelector( `#ffz-mmu-mass-${tool.toolName}-tool-entry-count` ).textContent = tool.entriesListTextArea.value.trim().split( /[\r\n|\r|\n]/ ).filter( Boolean ).length;
 }
+
+export function detectEnterKey( banTool, e ) {
+    const fieldType = e.target.dataset.fieldType;
+
+    if ( e.key === 'Enter' ) {
+        if ( fieldType === 'count' ) {
+            const value = parseInt( document.getElementById( 'ffz-mmu-mass-ban-tool-recent-followers-import-custom-amount' ).value );
+
+            if ( ! isNaN( value ) ) {
+                banTool.importRecentFollowers( e, value );
+            }
+        } else if ( fieldType === 'timestamp' ) {
+            banTool.importRecentFollowers( e, 1000 );
+        }
+
+        e.target.value = '';
+    }
+}

--- a/src/mass-ban-tool/utils/graphql/recent-followers.gql
+++ b/src/mass-ban-tool/utils/graphql/recent-followers.gql
@@ -1,7 +1,9 @@
-query MassBanTool_GetRecentFollowers( $login: String!, $first: Int! ) {
+query MassBanTool_GetRecentFollowers( $login: String!, $first: Int!, $after: Cursor ) {
     user( login: $login ) {
-        followers( first: $first, order: DESC ) {
+        followers( first: $first, after: $after, order: DESC ) {
             edges {
+                cursor
+                followedAt
                 node {
                     displayName
                 }


### PR DESCRIPTION
* Added: Ability to import recent followers by timestamp (before/after specific times, or both) within the previous 72 hours in the mass ban tool
* Added: Show current progress count when importing recent followers by count in the mass ban tool
* Changed: Increased "Recent Followers (by count)" limit to 1000 followers in a single request in the mass ban tool