### PR TITLE
ReYohoho Emotes Proxy 1.0.0

### DIFF
--- a/src/7tv-emotes/index.js
+++ b/src/7tv-emotes/index.js
@@ -7,6 +7,8 @@ class SevenTVEmotes extends Addon {
 		this.addonID = this.name.replace(/^addon\./, '');
 
 		this.manifest = this.addons.getAddon(this.addonID);
+		
+		this.load_requires = ['addon.reyohoho-emotes-proxy'];
 	}
 
 	async onLoad() {

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2025-06-14T21:42:29.851Z"
+	"updated": "2025-07-06T02:03:44.354Z"
 }

--- a/src/7tv-emotes/modules/api.js
+++ b/src/7tv-emotes/modules/api.js
@@ -5,13 +5,42 @@ export default class API extends FrankerFaceZ.utilities.module.Module {
 		this.inject(User);
 		this.inject(Emotes);
 		this.inject(Cosmetics);
-
-		this.apiBaseURI = 'https://7tv.io/v3';
-		this.eventsBaseURI = 'https://events.7tv.io/v3';
-		this.appBaseURI = 'https://7tv.app';
+		this.inject('settings');
 
 		this.clientPlatform = 'ffz';
 		this.clientVersion = this.parent.manifest.version;
+		
+		this.updateBaseURIs();
+	}
+
+	updateBaseURIs() {
+		const proxySettings = this.resolve('addon.reyohoho-emotes-proxy');
+		const proxyUrl = proxySettings ? proxySettings.getProxyUrl() : null;
+		const isEnabled = proxySettings ? proxySettings.isServiceEnabled('7tv') : false;
+
+		if (proxyUrl && isEnabled) {
+			this.apiBaseURI = `${proxyUrl}https://7tv.io/v3`;
+			this.appBaseURI = `${proxyUrl}https://7tv.app`;
+		} else {
+			this.apiBaseURI = 'https://7tv.io/v3';
+			this.appBaseURI = 'https://7tv.app';
+		}
+		
+		this.eventsBaseURI = 'https://events.7tv.io/v3';
+	}
+
+	onEnable() {
+		this.settings.on('changed:addon.reyohoho-emotes-proxy.enabled', () => {
+			this.updateBaseURIs();
+		});
+		
+		this.settings.on('changed:addon.reyohoho-emotes-proxy.proxy-url', () => {
+			this.updateBaseURIs();
+		});
+		
+		this.settings.on('changed:addon.reyohoho-emotes-proxy.services', () => {
+			this.updateBaseURIs();
+		});
 	}
 
 	makeRequest(route, options = {}, skip_cache = false) {

--- a/src/7tv-emotes/modules/emotes.js
+++ b/src/7tv-emotes/modules/emotes.js
@@ -77,6 +77,19 @@ export default class Emotes extends FrankerFaceZ.utilities.module.Module {
 		this.on('settings:changed:addon.seventv_emotes.channel_emotes', () => this.updateChannelSets());
 		this.on('settings:changed:addon.seventv_emotes.unlisted_emotes', () => this.updateChannelSets());
 
+		this.on('settings:changed:addon.reyohoho-emotes-proxy.enabled', () => {
+			this.updateGlobalEmotes();
+			this.updateChannelSets();
+		});
+		this.on('settings:changed:addon.reyohoho-emotes-proxy.proxy-url', () => {
+			this.updateGlobalEmotes();
+			this.updateChannelSets();
+		});
+		this.on('settings:changed:addon.reyohoho-emotes-proxy.services', () => {
+			this.updateGlobalEmotes();
+			this.updateChannelSets();
+		});
+
 		this.on('chat:room-add', channel => this.updateChannelSet(channel));
 		this.on('chat:room-remove', channel => this.setChannelSet(channel, null));
 
@@ -333,15 +346,18 @@ export default class Emotes extends FrankerFaceZ.utilities.module.Module {
 		const formatEmoteVersions = emote.data.host.files.filter((value => value.format === format));
 		if (!formatEmoteVersions.length) return null;
 
+		const proxySettings = this.resolve('addon.reyohoho-emotes-proxy');
+		const proxyEmoteHostUrl = proxySettings ? proxySettings.applyProxy(emoteHostUrl, '7tv') : emoteHostUrl;
+
 		const emoteUrls = formatEmoteVersions.reduce((acc, value, key) => {
-			acc[key + 1] = `${emoteHostUrl}/${value.name}`;
+			acc[key + 1] = `${proxyEmoteHostUrl}/${value.name}`;
 			return acc;
 		}, {});
 
 		let staticEmoteUrls;
 		if (emote.data.animated) {
 			staticEmoteUrls = formatEmoteVersions.reduce((acc, value, key) => {
-				acc[key + 1] = `${emoteHostUrl}/${value.static_name}`;
+				acc[key + 1] = `${proxyEmoteHostUrl}/${value.static_name}`;
 				return acc;
 			}, {});
 		}

--- a/src/reyohoho-emotes-proxy/index.js
+++ b/src/reyohoho-emotes-proxy/index.js
@@ -1,0 +1,106 @@
+class ProxySettings extends Addon {
+	constructor(...args) {
+		super(...args);
+
+		this.inject('settings');
+		this.inject('i18n');
+	}
+
+	onEnable() {
+		this.settings.add('addon.reyohoho-emotes-proxy.enabled', {
+			default: true,
+			ui: {
+				sort: 0,
+				path: 'Add-Ons > ReYohoho Emotes Proxy',
+				title: 'Enable Proxy',
+				description: 'Enable proxy for 7TV and other services',
+				component: 'setting-check-box'
+			}
+		});
+
+		this.settings.add('addon.reyohoho-emotes-proxy.proxy-url', {
+			default: 'https://starege.rhhhhhhh.live/',
+			ui: {
+				sort: 1,
+				path: 'Add-Ons > ReYohoho Emotes Proxy',
+				title: 'Proxy URL',
+				description: 'Base URL for the proxy service',
+				component: 'setting-text-box',
+				placeholder: 'https://your-proxy.com/'
+			}
+		});
+
+		this.settings.add('addon.reyohoho-emotes-proxy.7tv-enabled', {
+			default: true,
+			ui: {
+				sort: 2,
+				path: 'Add-Ons > ReYohoho Emotes Proxy',
+				title: '7TV Emotes',
+				description: 'Use proxy for 7TV emotes',
+				component: 'setting-check-box'
+			}
+		});
+
+		this.settings.add('addon.reyohoho-emotes-proxy.bttv-enabled', {
+			default: false,
+			ui: {
+				sort: 3,
+				path: 'Add-Ons > ReYohoho Emotes Proxy',
+				title: 'BTTV Emotes (TODO)',
+				description: 'Use proxy for BTTV emotes - Coming soon',
+				component: 'setting-check-box',
+				disabled: true
+			}
+		});
+
+		this.settings.add('addon.reyohoho-emotes-proxy.ffz-enabled', {
+			default: false,
+			ui: {
+				sort: 4,
+				path: 'Add-Ons > ReYohoho Emotes Proxy',
+				title: 'FFZ Emotes (TODO)',
+				description: 'Use proxy for FFZ emotes - Coming soon',
+				component: 'setting-check-box',
+				disabled: true
+			}
+		});
+
+		this.log.info('Proxy Settings addon enabled');
+	}
+
+	getProxyUrl() {
+		if (!this.settings.get('addon.reyohoho-emotes-proxy.enabled')) {
+			return null;
+		}
+		return this.settings.get('addon.reyohoho-emotes-proxy.proxy-url');
+	}
+
+	isServiceEnabled(service) {
+		switch (service) {
+			case '7tv':
+				return this.settings.get('addon.reyohoho-emotes-proxy.7tv-enabled');
+			case 'bttv':
+				return this.settings.get('addon.reyohoho-emotes-proxy.bttv-enabled');
+			case 'ffz':
+				return this.settings.get('addon.reyohoho-emotes-proxy.ffz-enabled');
+			default:
+				return false;
+		}
+	}
+
+	applyProxy(url, service = '7tv') {
+		if (!this.getProxyUrl() || !this.isServiceEnabled(service)) {
+			return url;
+		}
+
+		const proxyUrl = this.getProxyUrl();
+		
+		if (url.startsWith('//')) {
+			return `${proxyUrl}https:${url}`;
+		}
+		
+		return url.replace(/^https?:\/\//, proxyUrl);
+	}
+}
+
+ProxySettings.register(); 

--- a/src/reyohoho-emotes-proxy/manifest.json
+++ b/src/reyohoho-emotes-proxy/manifest.json
@@ -1,0 +1,13 @@
+{
+	"enabled": true,
+	"requires": [],
+	"version": "1.0.0",
+	"short_name": "ReYohoho Emotes Proxy",
+	"name": "ReYohoho Emotes Proxy",
+	"author": "ReYohoho",
+	"description": "Configure proxy settings for FFZ, BTTV and 7TV emotes",
+	"settings": "add_ons.reyohoho-emotes-proxy",
+	"website": "https://t.me/ReYohoho",
+	"created": "2025-07-06T01:05:13.806Z",
+	"updated": "2025-07-06T02:03:44.354Z"
+}


### PR DESCRIPTION
Some 7tv/ffz/bttv endpoints are blocked in Russia

Also Roskomnadzor blocks standard browser extension methods (proxy/VPN), we have to use exotic ones. It would be great to add such functionality to be able to proxy API requests and get images via http-url-proxy.

PR was created in order to find out the authors' attitude to such functionality, what do you think about it? At the moment we have added a working solution for 7tv.

If the addon is approved, I will continue to work on adding FFZ/BTTV emotes and proxy for websocket.