### PR TITLE
Spoiler Hider

### DIFF
--- a/src/spoiler/index.js
+++ b/src/spoiler/index.js
@@ -33,8 +33,8 @@ class SpoilerHider extends Addon {
 			process(tokens, msg) {
 				let i = 0;
 
-				// Is there a better way of doing this?
-				// To prevent Twitch interface by showing spoiler, this overrides message body. 
+				// FIXME: Is there a better way of doing this? I don't think modifying msg object here is valid
+				// This is meant to prevent Twitch by showing the message, this overrides message body.
 				if (msg.reply)
 				{
 					const replyText = msg.reply.parentMessageBody;
@@ -46,15 +46,6 @@ class SpoilerHider extends Addon {
 					}
 				}
 
-				if (msg.messageBody)
-				{
-					const [_, startPos] = outerThis.findSpoilerTag([{type: "text", text: msg.messageBody}]);
-					if (startPos != null)
-					{
-						msg.messageBody = "(spoiler)";
-					}
-				}
-				
 				while (i < tokens.length)
 				{
 					// first find start of spoiler tag
@@ -62,6 +53,9 @@ class SpoilerHider extends Addon {
 					if (startPos == null)
 						break;
 
+					if (msg.messageBody)
+						msg.messageBody = "(spoiler)";
+				
 					const token = tokens[startIndex];
 
 					const visibleText = token.text.substring(0, startPos);

--- a/src/spoiler/index.js
+++ b/src/spoiler/index.js
@@ -1,4 +1,3 @@
-// Add-Ons should contain a class that extends Addon.
 class SpoilerHider extends Addon {
 	constructor(...args) {
 		super(...args);
@@ -135,14 +134,8 @@ class SpoilerHider extends Addon {
 		return [i, null]
 	}
 
-	// onLoad is called when the module is being loaded, prior to
-	// being enabled. If this method returns a Promise, FFZ will
-	// wait for the promise to resolve before considering the
-	// module as loaded.
 	async onLoad() {
-		// We don't actually need to do anything here, but if
-		// we did, we'd already have guaranteed access to the
-		// metadata module because of the earlier "load_requires"
+
 	}
 
 	onEnable() {

--- a/src/spoiler/index.js
+++ b/src/spoiler/index.js
@@ -21,8 +21,6 @@ class SpoilerHider extends Addon {
 					}} onClick={
 					() => {
 						token.revealed = !token.revealed;
-						console.log('Token onClick reveal: ', token)
-
 						// FIXME: is there anyways to render clicks in replies by messageId?
 						//outerThis.emit("chat:update-line", token.message.id, false);
 						outerThis.emit("chat:rerender-lines");

--- a/src/spoiler/index.js
+++ b/src/spoiler/index.js
@@ -1,0 +1,161 @@
+// Add-Ons should contain a class that extends Addon.
+class SpoilerHider extends Addon {
+	constructor(...args) {
+		super(...args);
+
+		this.inject('chat');
+		this.inject('site');
+
+		const outerThis = this;
+
+		this.messageFilter = {
+			type: 'spoiler_hidden',
+			priority: 9,
+
+			render(token, createElement) {
+				return (<span 
+					style={{
+						"background-color": token.revealed ? "var(--color-background-button-text-hover)" : "var(--color-background-alt)",
+						"borderRadius": "var(--border-radius-medium)",
+						"cursor": "pointer",
+						"display": "inline-block",
+					}} onClick={
+					() => {
+						token.revealed = !token.revealed;
+						console.log('Token onClick reveal: ', token)
+
+						// FIXME: is there anyways to render clicks in replies by messageId?
+						//outerThis.emit("chat:update-line", token.message.id, false);
+						outerThis.emit("chat:rerender-lines");
+					}
+				}>{token.revealed ? this.renderTokens(token.data, createElement) : '×××'}</span>)
+			},
+
+			process(tokens, msg) {
+				let i = 0;
+
+				// Is there a better way of doing this?
+				// To prevent Twitch interface by showing spoiler, this overrides message body. 
+				if (msg.reply)
+				{
+					const replyText = msg.reply.parentMessageBody;
+
+					const [_, startPos] = outerThis.findSpoilerTag([{type: "text", text: replyText}]);
+					if (startPos != null)
+					{
+						msg.reply.parentMessageBody = "(spoiler)";
+					}
+				}
+
+				if (msg.messageBody)
+				{
+					const [_, startPos] = outerThis.findSpoilerTag([{type: "text", text: msg.messageBody}]);
+					if (startPos != null)
+					{
+						msg.messageBody = "(spoiler)";
+					}
+				}
+				
+				while (i < tokens.length)
+				{
+					// first find start of spoiler tag
+					const [startIndex, startPos] = outerThis.findSpoilerTag(tokens);
+					if (startPos == null)
+						break;
+
+					const token = tokens[startIndex];
+
+					const visibleText = token.text.substring(0, startPos);
+					const spoilerText = token.text.substring(startPos + 2);
+					const newTokens = [
+						{ type: 'text', text: visibleText },
+					];
+
+					const afterTokens = 
+					[
+						{type: 'text', text: spoilerText},
+						...tokens.slice(startIndex + 1)
+					]
+
+					const [endIndex, endPos] = outerThis.findSpoilerTag(afterTokens);
+
+					const spoilerToken = {
+						type: 'spoiler_hidden',
+						revealed: false,
+						message: msg,
+						data: afterTokens.slice(0, endIndex)
+					};
+
+					newTokens.push(spoilerToken)
+
+					if (endPos != null)
+					{
+						// found a closing tag
+						const endToken = afterTokens[endIndex];
+
+						const beforeEnd = endToken.text.substring(0, endPos);
+						const afterEnd = endToken.text.substring(endPos + 2);
+
+						if (beforeEnd)
+						{
+							spoilerToken.data.push(
+								{type: 'text', text: beforeEnd}
+							);
+						}
+						
+						if (afterEnd) newTokens.push({ type: 'text', text: afterEnd });
+					}
+
+					// Replace tokens
+            		tokens.splice(i, endIndex + 1, ...newTokens);
+            		i += newTokens.length - 1; // process the text token again for another spoiler  
+				}
+				return tokens;
+			}
+		}
+	}
+
+	findSpoilerTag(tokens)
+	{
+		let i = 0;
+
+		while (i < tokens.length)
+		{
+			const token = tokens[i];
+
+			if (token.type === 'text')
+			{
+				const spoiler_tag = "||";
+				const spoiler_pos = token.text.indexOf(spoiler_tag);
+				if (spoiler_pos >= 0)
+					return [i, spoiler_pos];	
+			}
+			i++;
+		}
+		return [i, null]
+	}
+
+	// onLoad is called when the module is being loaded, prior to
+	// being enabled. If this method returns a Promise, FFZ will
+	// wait for the promise to resolve before considering the
+	// module as loaded.
+	async onLoad() {
+		// We don't actually need to do anything here, but if
+		// we did, we'd already have guaranteed access to the
+		// metadata module because of the earlier "load_requires"
+	}
+
+	onEnable() {
+		this.chat.addTokenizer(this.messageFilter);
+	}
+
+	onDisable() {
+		this.chat.removeTokenizer(this.messageFilter);
+	}
+
+	async onUnload() {
+		/* no-op */
+	}
+}
+
+SpoilerHider.register();

--- a/src/spoiler/manifest.json
+++ b/src/spoiler/manifest.json
@@ -1,0 +1,13 @@
+{
+    "enabled": false,
+    "requires": [],
+
+    "version": "1.0.0",
+
+    "short_name": "spoiler_hidden",
+    "name": "Spoiler Hider",
+    "author": "TheDaChicken",
+    "description": "Allows for users in chat to spoil messages using || similar to markdown! Useful for playing games spoiler free!",
+
+    "website": "https://www.thedachicken.com"
+}

--- a/src/spoiler/manifest.json
+++ b/src/spoiler/manifest.json
@@ -8,5 +8,5 @@
 	"description": "Allows for users in chat to spoil messages using || similar to markdown! Useful for playing games spoiler free!",
 	"website": "https://www.thedachicken.com",
 	"created": "2025-09-14T23:19:29.152Z",
-	"updated": "2025-09-14T23:19:29.152Z"
+	"updated": "2025-09-14T23:24:06.572Z"
 }

--- a/src/spoiler/manifest.json
+++ b/src/spoiler/manifest.json
@@ -1,13 +1,12 @@
 {
-    "enabled": false,
-    "requires": [],
-
-    "version": "1.0.0",
-
-    "short_name": "spoiler_hidden",
-    "name": "Spoiler Hider",
-    "author": "TheDaChicken",
-    "description": "Allows for users in chat to spoil messages using || similar to markdown! Useful for playing games spoiler free!",
-
-    "website": "https://www.thedachicken.com"
+	"enabled": true,
+	"requires": [],
+	"version": "1.0.0",
+	"short_name": "spoiler_hidden",
+	"name": "Spoiler Hider",
+	"author": "TheDaChicken",
+	"description": "Allows for users in chat to spoil messages using || similar to markdown! Useful for playing games spoiler free!",
+	"website": "https://www.thedachicken.com",
+	"created": "2025-09-14T23:19:29.152Z",
+	"updated": "2025-09-14T23:19:29.152Z"
 }


### PR DESCRIPTION
Hi,

I wanted to make an ffz addon to help fix the problem that some streamers have. There is no way to talk about game spoilers in Twitch chat without the streamer seeing the messages! 

I implemented (what might be an odd solution) to this that I was capable of doing from looking at the addon examples. When text is spoiled in chat similar to markdown ""|| cheese ||"" then it won't be displayed unless clicked. 

I would like to get this added to FFZ. I am willing to make changes to improve things. For example, I couldn't find a way to properly rerender when clicking a specific message in replies. I also had to edit parentMessageBody to prevent spoilers from showing up in the text header of replies. 
