### PR TITLE
Update: Trubbel’s Utilities 4.4.0

### DIFF
--- a/src/trubbel/components/main_menu/animated-emote-blocklist.vue
+++ b/src/trubbel/components/main_menu/animated-emote-blocklist.vue
@@ -28,7 +28,14 @@
           <span class="tw-flex-grow-1 tw-font-size-6 tw-flex tw-align-items-center">
             {{ emote.name }}
 
-            <img :src="emoteURL(emote)" :alt="emote.name" class="tw-mg-l-1" style="height: 28px;" />
+            <img
+              :src="staticEmoteURL(emote)"
+              :alt="emote.name"
+              class="tw-mg-l-1"
+              style="height: 28px;"
+              @mouseenter="e => e.target.src = emoteURL(emote)"
+              @mouseleave="e => e.target.src = staticEmoteURL(emote)"
+            />
           </span>
 
           <button class="tw-button tw-button--text ffz-il-tooltip__container" @click="remove(emote)">
@@ -89,9 +96,7 @@ export default {
     emoteURL(emote) {
       if (!emote || !emote.id) return "";
 
-      const source = emote.source;
-
-      switch (source) {
+      switch (emote.source) {
         case "ffz":
           return `https://cdn.frankerfacez.com/emote/${emote.id}/4`;
 
@@ -104,6 +109,25 @@ export default {
         case "twitch":
         default:
           return `https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/default/dark/4.0`;
+      }
+    },
+
+    staticEmoteURL(emote) {
+      if (!emote || !emote.id) return "";
+
+      switch (emote.source) {
+        case "ffz":
+          return `https://cdn.frankerfacez.com/emote/${emote.id}/4`;
+
+        case "7tv":
+          return `https://cdn.7tv.app/emote/${emote.id}/4x_static.webp`;
+
+        case "bttv":
+          return `https://cdn.betterttv.net/emote/${emote.id}/static/3x.webp`;
+
+        case "twitch":
+        default:
+          return `https://static-cdn.jtvnw.net/emoticons/v2/${emote.id}/static/dark/4.0`;
       }
     }
   }

--- a/src/trubbel/components/main_menu/experiments-eppo.vue
+++ b/src/trubbel/components/main_menu/experiments-eppo.vue
@@ -1,0 +1,297 @@
+<template>
+  <div class="ffz--experiments-eppo ffz--experiments tw-pd-t-05">
+    <div class="tw-pd-b-1 tw-mg-b-1 tw-border-b">
+      This feature allows you to override Eppo experiment values. Please note that, for most experiments, you may have to refresh the page for your changes to take effect.
+    </div>
+
+    <div class="tw-mg-b-2 tw-flex tw-align-items-center">
+      <div class="tw-flex-grow-1">
+        {{ visible_flags.length }} flag{{ visible_flags.length === 1 ? '' : 's' }}
+      </div>
+      <select
+        ref="sort_select"
+        class="tw-border-radius-medium ffz-font-size-6 ffz-select tw-pd-l-1 tw-pd-r-3 tw-pd-y-05 tw-mg-x-05"
+        @change="onSort"
+      >
+        <option :selected="sort_by === 0">
+          Sort By: Name
+        </option>
+        <option :selected="sort_by === 1">
+          Sort By: Type
+        </option>
+      </select>
+    </div>
+
+    <div class="tw-mg-b-2 tw-flex tw-align-items-center">
+      <div class="tw-flex-grow-1" />
+      <div class="ffz-checkbox tw-relative">
+        <input
+          id="show-disabled"
+          v-model="show_disabled"
+          type="checkbox"
+          class="ffz-checkbox__input"
+        >
+        <label for="show-disabled" class="ffz-checkbox__label">
+          <span class="tw-mg-l-1">
+            Show disabled flags
+          </span>
+        </label>
+      </div>
+    </div>
+
+    <h3 class="tw-mg-t-1 tw-mg-b-1 ffz-font-size-3">
+      <span>Twitch Eppo Experiments</span>
+    </h3>
+
+    <section v-if="experiments_locked">
+      <div class="tw-c-background-accent tw-c-text-overlay tw-pd-1 tw-mg-b-2">
+        <h3 class="ffz-i-attention ffz-font-size-3">
+          It's dangerous to go at all.
+        </h3>
+        <markdown :source="'Be careful, this is an advanced feature intended for developer use only. Normal users should steer clear. Adjusting your eppo experiments can have unexpected impacts on your Twitch experience. FrankerFaceZ is not responsible for any issues you encounter as a result of tampering with experiments, and we will not provide support.\n\nIf you\'re sure about this, please type `' + code + '` into the box below and hit enter.'" />
+      </div>
+
+      <div class="tw-flex tw-align-items-center">
+        <input
+          ref="code"
+          type="text"
+          class="tw-block tw-full-width tw-border-radius-medium ffz-font-size-6 tw-full-width ffz-input tw-pd-x-1 tw-pd-y-05 tw-mg-b-5"
+          autocapitalize="off"
+          autocorrect="off"
+          @keydown.enter="enterCode"
+        >
+      </div>
+    </section>
+
+    <div v-else class="ffz--experiment-list">
+      <section
+        v-for="{key, flag} of visible_flags"
+        :key="key"
+        :data-key="key"
+      >
+        <div class="tw-elevation-1 tw-c-background-base tw-border tw-pd-y-05 tw-pd-x-1 tw-mg-y-05 tw-flex tw-flex-nowrap">
+          <div class="tw-flex-grow-1">
+            <h4 class="ffz-font-size-4">
+              {{ key }}
+              <span v-if="flag.has_override" class="tw-c-text-alt-2">
+                (Overridden)
+              </span>
+            </h4>
+            <div class="description tw-c-text-alt-2">
+              Type: {{ flag.variationType }}
+              <span v-if="flag.entityId"> • Entity ID: {{ flag.entityId }}</span>
+              <span v-if="!flag.enabled"> • Disabled</span>
+            </div>
+          </div>
+
+          <div class="tw-flex tw-flex-shrink-0 tw-align-items-start">
+            <select
+              v-if="flag.variationType === 'BOOLEAN' || flag.variationType === 'STRING'"
+              :data-key="key"
+              :value="flag.current_value"
+              class="tw-border-radius-medium ffz-font-size-6 ffz-select tw-pd-l-1 tw-pd-r-3 tw-pd-y-05 tw-mg-x-05"
+              @change="onChange($event)"
+            >
+              <option
+                v-for="variation in flag.variations"
+                :key="variation.key"
+                :value="variation.value"
+              >
+                {{ variation.key }}
+              </option>
+            </select>
+
+            <input
+              v-else-if="flag.variationType === 'INTEGER'"
+              type="number"
+              :data-key="key"
+              :value="flag.current_value"
+              class="tw-border-radius-medium ffz-font-size-6 ffz-input tw-pd-l-1 tw-pd-r-1 tw-pd-y-05 tw-mg-x-05"
+              style="width: 120px;"
+              @change="onChange($event)"
+            >
+
+            <textarea
+              v-else-if="flag.variationType === 'JSON'"
+              :data-key="key"
+              :value="typeof flag.current_value === 'object' ? JSON.stringify(flag.current_value, null, 2) : flag.current_value"
+              class="tw-border-radius-medium ffz-font-size-6 ffz-input tw-pd-l-1 tw-pd-r-1 tw-pd-y-05 tw-mg-x-05"
+              style="width: 300px; height: 80px; font-family: monospace;"
+              @change="onChange($event)"
+            />
+
+            <input
+              v-else
+              type="text"
+              :data-key="key"
+              :value="typeof flag.current_value === 'object' ? JSON.stringify(flag.current_value) : flag.current_value"
+              class="tw-border-radius-medium ffz-font-size-6 ffz-input tw-pd-l-1 tw-pd-r-1 tw-pd-y-05 tw-mg-x-05"
+              style="width: 200px;"
+              @change="onChange($event)"
+            >
+
+            <button
+              :disabled="!flag.has_override"
+              :class="{'tw-button--disabled': !flag.has_override}"
+              class="tw-mg-t-05 tw-button tw-button--text ffz-il-tooltip__container"
+              @click="reset(key)"
+            >
+              <span class="tw-button__text ffz-i-cancel" />
+              <span class="ffz-il-tooltip ffz-il-tooltip--down ffz-il-tooltip--align-right">
+                Reset to Default
+              </span>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <div v-if="!sorted_flags.length">
+        There are no Eppo flags available.
+      </div>
+      <div v-else-if="!visible_flags.length">
+        There are no matching flags.
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+
+const { pick_random } = FrankerFaceZ.utilities.object;
+
+const CODES = [
+  'sv_cheats 1',
+  'idspispopd',
+  'rosebud',
+  'how do you turn this on'
+];
+
+export default {
+  props: ['item', 'context'],
+
+  data() {
+    return {
+      code: pick_random(CODES),
+      experiments_locked: this.item.is_locked(),
+      sort_by: 0,
+      show_disabled: false,
+      eppo_data: {},
+    };
+  },
+
+  computed: {
+    sorted_flags() {
+      const out = [];
+
+      for (const [key, flag] of Object.entries(this.eppo_data)) {
+        if (!this.show_disabled && !flag.enabled) continue;
+
+        const variationsList = flag.variations
+          ? Object.entries(flag.variations).map(([varKey, varData]) => ({
+              key: varKey,
+              value: varData.value,
+            }))
+          : [];
+
+        out.push({
+          key,
+          flag: {
+            ...flag,
+            variations: variationsList,
+            current_value: this.item.getAssignment?.(key),
+            has_override: this.item.hasOverride?.(key) ?? false,
+          },
+        });
+      }
+
+      out.sort((a, b) => {
+        if (a.flag.has_override !== b.flag.has_override) {
+          return a.flag.has_override ? -1 : 1;
+        }
+
+        if (this.sort_by === 1) {
+          const typeCompare = (a.flag.variationType ?? '').localeCompare(b.flag.variationType ?? '');
+          if (typeCompare !== 0) return typeCompare;
+        }
+
+        return a.key.localeCompare(b.key);
+      });
+
+      return out;
+    },
+
+    visible_flags() {
+      const filter = this.context?.context?.search_filter;
+      if (!filter) return this.sorted_flags;
+
+      const lower = filter.toLowerCase();
+
+      return this.sorted_flags.filter(({ key, flag }) => {
+        if (key.toLowerCase().includes(lower)) return true;
+        if (flag.variationType?.toLowerCase().includes(lower)) return true;
+        if (flag.variations?.some(v => v.key.toLowerCase().includes(lower))) return true;
+        return false;
+      });
+    },
+  },
+
+  created() {
+    this.loadData();
+
+    this._eppoHandler = () => this.loadData();
+    this.item.on?.(':eppo-changed', this._eppoHandler);
+  },
+
+  beforeDestroy() {
+    this.item.off?.(':eppo-changed', this._eppoHandler);
+  },
+
+  methods: {
+    loadData() {
+      if (this.item.eppo_data) {
+        this.eppo_data = this.item.eppo_data();
+      }
+    },
+
+    enterCode() {
+      if (this.$refs.code.value !== this.code)
+        return;
+
+      this.experiments_locked = false;
+      this.item.unlock();
+    },
+
+    onSort() {
+      this.sort_by = this.$refs.sort_select.selectedIndex;
+    },
+
+    onChange(event) {
+      const key = event.target.dataset.key;
+      if (!key) return;
+
+      let value = event.target.value;
+      const variationType = this.item.getVariationType?.(key);
+
+      if (variationType === 'INTEGER') {
+        value = parseInt(value, 10);
+      } else if (variationType === 'BOOLEAN') {
+        value = value === 'true' || value === true;
+      } else if (variationType === 'JSON') {
+        try {
+          value = JSON.parse(value);
+        } catch (e) {
+          console.error('[Eppo] Invalid JSON value:', e);
+          return;
+        }
+      }
+
+      this.item.setOverride?.(key, value);
+    },
+
+    reset(key) {
+      if (!key) return;
+      this.item.deleteOverride?.(key);
+    },
+  },
+};
+</script>

--- a/src/trubbel/components/main_menu/icon-finder.vue
+++ b/src/trubbel/components/main_menu/icon-finder.vue
@@ -1,0 +1,236 @@
+<template lang="html">
+  <div class="trubbel-icon-browser tw-pd-1">
+
+    <div class="tw-flex tw-align-items-center tw-flex-nowrap tw-mg-b-1" style="gap: 8px;">
+      <input v-model="search"
+        class="ffz-input tw-flex-grow-1 tw-border-radius-medium ffz-font-size-6 tw-pd-x-1 tw-pd-y-05"
+        placeholder="Search by name or path data..." type="text">
+      <button class="tw-button" :disabled="scanning" @click="rescan">
+        <span class="tw-button__text">
+          {{ scanning ? 'Scanning…' : (icons.length ? `Rescan (${icons.length})` : 'Scan Icons') }}
+        </span>
+      </button>
+    </div>
+
+    <div v-if="!icons.length && !scanning" class="tw-pd-2 tw-align-center tw-c-text-alt">
+      <p>Click <strong>Scan Icons</strong> to find all Twitch SVG icon components in webpack.</p>
+    </div>
+
+    <div v-if="scanning" class="tw-pd-2 tw-align-center tw-c-text-alt">
+      Scanning webpack modules…
+    </div>
+
+    <div v-if="filteredIcons.length" class="trubbel-icon-grid">
+      <div v-for="icon in filteredIcons" :key="icon.id" class="trubbel-icon-cell ffz-tooltip"
+        :class="{ 'trubbel-icon-cell--active': selected && selected.id === icon.id }"
+        :data-title="`<span style='font-size:var(--font-size-6);
+            font-weight:var(--font-weight-semibold);
+            line-height:var(--line-height-heading);
+            padding:3px 6px;
+            display:block;
+            white-space:nowrap
+          '>${icon.displayName || icon.id}</span>`"
+          data-tooltip-type="html"
+          @click="selectIcon(icon)">
+        <svg width="24" height="24" :viewBox="icon.viewBox" focusable="false" aria-hidden="true" role="presentation"
+          style="fill: currentColor; pointer-events: none;">
+        <template v-for="(p, idx) in icon.paths">
+          <polygon v-if="p.type === 'polygon'" :key="'poly-' + idx" :points="p.d" />
+          <path v-else :key="'path-' + idx" fill-rule="evenodd" clip-rule="evenodd" :d="p.d" />
+        </template>
+        </svg>
+      </div>
+    </div>
+
+    <div v-if="search && !filteredIcons.length && icons.length" class="tw-pd-1 tw-c-text-alt">
+      No icons matched <code>{{ search }}</code>.
+    </div>
+
+    <div v-if="selected"
+      class="trubbel-icon-detail tw-elevation-1 tw-c-background-alt tw-border tw-border-radius-large tw-pd-2 tw-mg-t-1">
+
+      <div class="tw-flex tw-align-items-start tw-flex-nowrap tw-mg-b-1" style="gap: 16px;">
+        <div class="trubbel-icon-detail-preview">
+          <svg width="80" height="80" :viewBox="selected.viewBox" focusable="false" aria-hidden="true" role="presentation"
+            style="fill: currentColor;">
+          <template v-for="(p, idx) in selected.paths">
+            <polygon v-if="p.type === 'polygon'" :key="'poly-' + idx" :points="p.d" />
+            <path v-else :key="'path-' + idx" fill-rule="evenodd" clip-rule="evenodd" :d="p.d" />
+          </template>
+          </svg>
+        </div>
+
+        <div class="tw-flex-grow-1">
+          <div v-if="selected.displayName" class="tw-mg-b-05">
+            <span class="tw-strong">Name: </span>
+            <code class="tw-c-text-alt-2">{{ selected.displayName }}</code>
+          </div>
+          <div class="tw-mg-b-05">
+            <span class="tw-strong">Module ID: </span>
+            <code class="tw-c-text-alt-2">{{ selected.id }}</code>
+          </div>
+          <div class="tw-mg-b-1 tw-c-text-alt-2" style="font-size: 11px;">
+            {{ selected.paths.length }} path{{ selected.paths.length !== 1 ? 's' : '' }}
+          </div>
+
+          <div class="tw-flex tw-flex-wrap" style="gap: 6px;">
+            <button class="tw-button ffz-button--hollow" @click="copySvgMarkup">
+              <span class="tw-button__icon tw-button__icon--left">
+                <figure class="ffz-i-docs" />
+              </span>
+              <span class="tw-button__text">Copy SVG</span>
+            </button>
+
+            <button class="tw-button ffz-button--hollow" @click="downloadSvg">
+              <span class="tw-button__icon tw-button__icon--left">
+                <figure class="ffz-i-download" />
+              </span>
+              <span class="tw-button__text">Download SVG</span>
+            </button>
+
+            <button class="tw-button ffz-button--hollow" @click="downloadPng">
+              <span class="tw-button__icon tw-button__icon--left">
+                <figure class="ffz-i-download" />
+              </span>
+              <span class="tw-button__text">Download PNG</span>
+            </button>
+          </div>
+
+          <div v-if="feedback" class="tw-mg-t-05 tw-c-text-success ffz-font-size-6">
+            {{ feedback }}
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+
+<script>
+
+import { buildSvgString } from "../../settings/twilight/icon-finder.js";
+
+export default {
+  props: ["item", "context"],
+
+  data() {
+    return {
+      icons: [],
+      selected: null,
+      search: "",
+      scanning: false,
+      feedback: "",
+      feedbackTimer: null
+    };
+  },
+
+  computed: {
+    filteredIcons() {
+      if (!this.search.trim()) {
+        return this.icons;
+      }
+
+      const q = this.search.toLowerCase();
+      return this.icons.filter(icon => {
+        return (
+          (icon.displayName && icon.displayName.toLowerCase().includes(q)) ||
+          icon.id.toLowerCase().includes(q) ||
+          icon.paths.some(p => p.d.toLowerCase().includes(q))
+        );
+      });
+    },
+
+    findCode() {
+      if (!this.selected) return "";
+      return this.item.generateFind(this.selected);
+    },
+
+    selectedSvgString() {
+      if (!this.selected) return "";
+      return buildSvgString(this.selected.paths, { viewBox: this.selected.viewBox });
+    }
+  },
+
+  mounted() {
+    const cached = this.item.getIcons();
+    if (cached?.length)
+      this.icons = cached;
+  },
+
+  methods: {
+    async rescan() {
+      this.selected = null;
+      this.scanning = true;
+      this.icons = [];
+      await this.$nextTick();
+      await new Promise(r => setTimeout(r, 50));
+      this.icons = this.item.rescan();
+      this.scanning = false;
+    },
+
+    selectIcon(icon) {
+      this.selected = (this.selected?.id === icon.id) ? null : icon;
+      this.feedback = "";
+    },
+
+    copyText(text, msg = "Copied!") {
+      navigator.clipboard.writeText(text).then(() => {
+        this.showFeedback(msg);
+      }).catch(() => {
+        const el = document.createElement("textarea");
+        el.value = text;
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand("copy");
+        document.body.removeChild(el);
+        this.showFeedback(msg);
+      });
+    },
+
+    showFeedback(msg) {
+      this.feedback = msg;
+      clearTimeout(this.feedbackTimer);
+      this.feedbackTimer = setTimeout(() => { this.feedback = ""; }, 2000);
+    },
+
+    copySvgMarkup() {
+      this.copyText(this.selectedSvgString, "SVG markup copied!");
+    },
+
+    downloadSvg() {
+      if (!this.selected) return;
+      const blob = new Blob([this.selectedSvgString], { type: "image/svg+xml" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${this.selected.displayName || "twitch-icon-" + this.selected.id}.svg`;
+      a.click();
+      URL.revokeObjectURL(url);
+      this.showFeedback("SVG downloaded!");
+    },
+
+    downloadPng() {
+      if (!this.selected) return;
+      const svg = buildSvgString(this.selected.paths, { fill: "#efeff1", size: 128, viewBox: this.selected.viewBox });
+      const img = new Image();
+      const blob = new Blob([svg], { type: "image/svg+xml" });
+      const url = URL.createObjectURL(blob);
+      img.onload = () => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 128;
+        canvas.height = 128;
+        canvas.getContext("2d").drawImage(img, 0, 0, 128, 128);
+        URL.revokeObjectURL(url);
+        const a = document.createElement("a");
+        a.href = canvas.toDataURL("image/png");
+        a.download = `${this.selected.displayName || "twitch-icon-" + this.selected.id}.png`;
+        a.click();
+        this.showFeedback("PNG downloaded!");
+      };
+      img.src = url;
+    }
+  }
+};
+
+</script>

--- a/src/trubbel/components/main_menu/styles/icon-finder.scss
+++ b/src/trubbel/components/main_menu/styles/icon-finder.scss
@@ -1,0 +1,51 @@
+.trubbel-icon-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
+	gap: 4px;
+	max-height: 400px;
+	overflow-y: auto;
+	padding: 4px 0;
+}
+.trubbel-icon-cell {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 44px;
+	height: 44px;
+	border-radius: 6px;
+	cursor: pointer;
+	color: var(--color-text-base, #efeff1);
+	border: 2px solid transparent;
+	transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.trubbel-icon-cell:hover {
+	background-color: var(--color-background-button-text-hover, rgba(255,255,255,0.1));
+	border-color: var(--color-border-input-focus, #a970ff);
+}
+.trubbel-icon-cell--active {
+	border-color: var(--color-border-input-focus, #a970ff);
+	background-color: var(--color-background-button-text-active, rgba(169,112,255,0.15));
+}
+.trubbel-icon-detail-preview {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 96px;
+	height: 96px;
+	flex-shrink: 0;
+	border-radius: 10px;
+	background-image: repeating-linear-gradient(
+		45deg,
+		rgba(255,255,255,0.06) 0,
+		rgba(255,255,255,0.06) 8px,
+		transparent 8px,
+		transparent 16px
+	);
+	color: var(--color-text-base, #efeff1);
+}
+.trubbel-icon-path {
+	transition: background-color 0.1s;
+}
+.trubbel-icon-path:hover {
+	background-color: var(--color-background-button-text-hover, rgba(255,255,255,0.08)) !important;
+}

--- a/src/trubbel/components/main_menu/text-replace.vue
+++ b/src/trubbel/components/main_menu/text-replace.vue
@@ -1,0 +1,216 @@
+<template lang="html">
+	<div class="tr--rules-editor">
+
+		<div class="tw-border tw-border-radius-medium tw-pd-1 tw-mg-b-1">
+			<div class="tw-c-text-alt-2 tw-font-size-6 tw-mg-b-05">
+				Rule Tester
+			</div>
+			<input
+				v-model="tester_input"
+				class="ffz-input tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-full-width tw-mg-b-05"
+				placeholder="Type a message to preview rule output"
+			>
+			<input
+				:value="tester_output"
+				class="ffz-input tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-full-width"
+				placeholder="Output will appear here"
+				readonly
+				style="opacity: 0.7"
+			>
+		</div>
+
+		<div v-if="!rules.length" class="tw-c-text-alt-2 tw-font-size-6 tw-pd-y-05">
+			No rules yet. Click "Add Rule" below to get started.
+		</div>
+
+		<div
+			v-for="(rule, index) in rules"
+			:key="rule.id"
+			class="tw-border tw-border-radius-medium tw-mg-b-05"
+		>
+			<div
+				class="tw-flex tw-align-items-center tw-pd-x-1 tw-pd-y-05 tw-interactive"
+				style="cursor: pointer;"
+				@click="toggleExpanded(rule.id)"
+			>
+				<span class="tw-flex-grow-1 tw-font-size-6">
+					<template v-if="rule.find">
+						Rule {{ index + 1 }}
+						<span class="tw-c-text-alt-2"> - {{ rule.find }}</span>
+						<span v-if="rule.isRegex" class="ffz-pill tw-mg-l-05" style="font-size: 1rem;">regex</span>
+					</template>
+					<span v-else class="tw-c-text-alt-2">Empty Rule {{ index + 1 }}</span>
+				</span>
+				<span :class="isExpanded(rule.id) ? 'ffz-i-up-dir' : 'ffz-i-down-dir'" />
+			</div>
+
+			<div v-if="isExpanded(rule.id)" class="tw-pd-1 tw-border-t">
+				<div class="ffz-checkbox tw-mg-b-1">
+					<input
+						:id="'tr-regex-' + rule.id"
+						:checked="rule.isRegex"
+						type="checkbox"
+						class="ffz-checkbox__input"
+						@change="setField(index, 'isRegex', $event.target.checked)"
+					>
+					<label :for="'tr-regex-' + rule.id" class="ffz-checkbox__label">
+						<span class="tw-mg-l-1">Use Regular Expression</span>
+					</label>
+				</div>
+
+				<div style="display:grid; grid-template-columns:max-content 1fr; gap:0.4em 1em; align-items:start;">
+					<label class="tw-c-text-alt-2 tw-font-size-6" style="padding-top:0.35em;">Find</label>
+					<div>
+						<input
+							:value="rule.find"
+							:class="{'ffz-input--error': rule.isRegex && getRegexError(rule.find)}"
+							class="ffz-input tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-full-width"
+							:placeholder="rule.isRegex ? 'Regular expression pattern' : 'Text to find'"
+							@change="setField(index, 'find', $event.target.value)"
+						>
+						<div v-if="rule.isRegex && getRegexError(rule.find)" class="tw-c-text-alt-2 tw-font-size-7 tw-mg-t-05" style="color: var(--color-text-error, #f33);">
+							{{ getRegexError(rule.find) }}
+						</div>
+					</div>
+
+					<label class="tw-c-text-alt-2 tw-font-size-6" style="padding-top:0.35em;">Replace</label>
+					<input
+						:value="rule.replace"
+						class="ffz-input tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-full-width"
+						placeholder="Replacement text (leave blank to delete matches)"
+						@change="setField(index, 'replace', $event.target.value)"
+					>
+
+					<label class="tw-c-text-alt-2 tw-font-size-6" style="padding-top:0.35em;">Only if includes</label>
+					<input
+						:value="rule.onlyIfIncludes"
+						class="ffz-input tw-border-radius-medium tw-font-size-6 tw-pd-x-1 tw-pd-y-05 tw-full-width"
+						placeholder="Optional - only apply if message contains this text"
+						@change="setField(index, 'onlyIfIncludes', $event.target.value)"
+					>
+				</div>
+
+				<button
+					class="tw-button tw-button--text tw-full-width tw-mg-t-1"
+					style="color: var(--color-text-error, #f33);"
+					@click="removeRule(index)"
+				>
+					<span class="tw-button__text ffz-i-cancel">
+						Delete Rule
+					</span>
+				</button>
+			</div>
+		</div>
+
+		<button class="tw-button tw-full-width tw-mg-t-05" @click="addRule">
+			<span class="tw-button__text ffz-i-plus">
+				Add Rule
+			</span>
+		</button>
+
+	</div>
+</template>
+
+<script>
+
+let last_id = 0;
+
+function makeRule() {
+	return {
+		id: ++last_id,
+		find: "",
+		replace: "",
+		onlyIfIncludes: "",
+		isRegex: false,
+	};
+}
+
+function applyRules(msg, rules) {
+	for (const rule of rules) {
+		if (!rule.find) continue;
+		if (rule.onlyIfIncludes && !msg.includes(rule.onlyIfIncludes)) continue;
+
+		if (rule.isRegex) {
+			try {
+				msg = msg.replace(new RegExp(rule.find, "g"), rule.replace ?? "");
+			} catch (_) { /* invalid regex */ }
+		} else {
+			msg = msg.replaceAll(rule.find, rule.replace ?? "");
+		}
+	}
+	return msg;
+}
+
+export default {
+	props: ["item", "context"],
+
+	data() {
+		const loaded = (this.item.getRules() ?? []).map(r => ({
+			id: ++last_id,
+			find: r.find ?? "",
+			replace: r.replace ?? "",
+			onlyIfIncludes: r.onlyIfIncludes ?? "",
+			isRegex: r.isRegex ?? false,
+		}));
+
+		return {
+			rules: loaded,
+			expanded: {},
+			tester_input: "",
+		};
+	},
+
+	computed: {
+		tester_output() {
+			if (!this.tester_input.length)
+				return "";
+
+			return applyRules(this.tester_input, this.rules);
+		},
+	},
+
+	methods: {
+		isExpanded(id) {
+			return !!this.expanded[id];
+		},
+
+		toggleExpanded(id) {
+			this.$set(this.expanded, id, !this.expanded[id]);
+		},
+
+		getRegexError(pattern) {
+			if (!pattern) return null;
+			try {
+				new RegExp(pattern);
+				return null;
+			} catch (e) {
+				return String(e);
+			}
+		},
+
+		addRule() {
+			const rule = makeRule();
+			this.rules.push(rule);
+
+			this.$set(this.expanded, rule.id, true);
+			this.save();
+		},
+
+		removeRule(index) {
+			this.rules.splice(index, 1);
+			this.save();
+		},
+
+		setField(index, field, value) {
+			this.$set(this.rules[index], field, value);
+			this.save();
+		},
+
+		save() {
+			const toSave = this.rules.map(({ id, ...rest }) => rest);
+			this.item.setRules(toSave);
+		}
+	}
+};
+
+</script>

--- a/src/trubbel/index.js
+++ b/src/trubbel/index.js
@@ -21,6 +21,8 @@ import { Inventory_Drops } from "./settings/inventory/drops";
 
 // Twilight
 import { Twilight_Clips } from "./settings/twilight/clips";
+import { Twilight_Experiments } from "./settings/twilight/experiments";
+import { Twilight_IconFinder } from "./settings/twilight/icon-finder";
 import { Twilight_Prime } from "./settings/twilight/prime";
 import { Twilight_Sidebar } from "./settings/twilight/sidebar";
 import { Twilight_Timestamp } from "./settings/twilight/timestamp";
@@ -60,14 +62,16 @@ class Trubbel extends Addon {
       this.inject(Inventory_Drops);
 
       // Twilight
+      this.inject(Twilight_IconFinder);
       this.inject(Twilight_Prime);
       this.inject(Twilight_Sidebar);
       this.inject(Twilight_Timestamp);
       this.inject(Twilight_Whispers);
     }
 
-    // Twilight - Clips
+    // Twilight
     this.inject(Twilight_Clips);
+    this.inject(Twilight_Experiments);
 
     this.loadDevBadge();
   }

--- a/src/trubbel/manifest.json
+++ b/src/trubbel/manifest.json
@@ -7,13 +7,13 @@
 	],
 	"name": "Trubbel\u2019s Utilities",
 	"short_name": "Trubbel",
-	"description": "↓ Lots of features ↓\n\n**Chat:**\n\n– Custom commands\n\n– First-time chatter indicator (for yourself)\n\n– Clickable Steam inspect links\n\n– Markdown support (bold, italic, underline, strikethrough, spoilers and timestamps)\n\n– Highlight messages\n\n– BTTV-like moderation\n\n– Raid preview (image, video)\n\n– Hide shared messages\n\n– Translate chat messages\n\n– Clickable usernames in /mods, /vips and raid messages\n\n– Display recent messages in viewer cards\n\n**Mod View:**\n\n– Activity feed moderation\n\n– Display emote and cheer tooltips in activity feed\n\n– Automatically enter mod view\n\n**Player:**\n\n– Automatically reset player on error\n\n**VODs:**\n\n– Custom progress bar\n\n– Custom seeking\n\n– Frame by frame seeking\n\n– Automatically skip muted segments\n\n**Dashboard:**\n\n– Show dashboard deletion date for past broadcasts\n\n**Directory:**\n\n– Display follow date in followed channels\n\n– Display total followed channels\n\n– Thumbnail previews\n\n**Inventory:**\n\n– Automatically claim drops\n\n– Collapsible drops\n\n**Overall:**\n\n– Yet Another Prime Reminder\n\n– Sidebar previews\n\n– Pinned sidebar channels\n\n– Automatically expand sidebar channels\n\n…among other things…",
+	"description": "↓ Lots of features ↓\n\n**Chat:**\n\n– Custom commands\n\n– First-time chatter indicator (for yourself)\n\n– Clickable Steam inspect links\n\n– Markdown support (bold, italic, underline, strikethrough, spoilers and timestamps)\n\n– Highlight messages\n\n– BTTV-like moderation\n\n– Raid preview (image, video)\n\n– Hide shared messages\n\n– Translate chat messages\n\n– Clickable usernames in /mods, /vips and raid messages\n\n– Display recent messages in viewer cards\n\n– Prediction browser notification\n\n– Text replace (regex)\n\n**Mod View:**\n\n– Activity feed moderation\n\n– Display emote and cheer tooltips in activity feed\n\n– Automatically enter mod view\n\n**Player:**\n\n– Automatically reset player on error\n\n– Download clip button\n\n**VODs:**\n\n– Automatically skip muted segments\n\n– Custom progress bar\n\n– Custom seeking\n\n– Disable click-to-pause on VODs\n\n– Frame by frame seeking\n\n**Dashboard:**\n\n– Show dashboard deletion date for past broadcasts\n\n**Directory:**\n\n– Display follow date in followed channels\n\n– Display total followed channels\n\n– Thumbnail previews\n\n**Inventory:**\n\n– Automatically claim drops\n\n– Collapsible drops\n\n**Overall:**\n\n– Yet Another Prime Reminder\n\n– Sidebar previews\n\n– Pinned sidebar channels\n\n– Automatically expand sidebar channels\n\n…among other things…",
 	"author": "Trubbel",
 	"maintainer": "Trubbel",
-	"version": "4.2.9",
+	"version": "4.4.0",
 	"search_terms": "trubbel",
 	"website": "https://twitch.tv/trubbel",
 	"settings": "add_ons.trubbel_s_utilities",
 	"created": "2025-01-06T23:29:54.496Z",
-	"updated": "2026-03-04T19:17:28.680Z"
+	"updated": "2026-04-16T02:22:47.075Z"
 }

--- a/src/trubbel/modules/appearance/declutter/index.js
+++ b/src/trubbel/modules/appearance/declutter/index.js
@@ -26,6 +26,7 @@ export default class Declutter {
       "hide-stream-monthly-recap": "div > div:has(> article a[href*=\"/recaps/\"])",
       "hide-watch-streak": ".rewards-list > div:has([style*=\"cursor: pointer\"] svg [d*=\"M5.295 8.05 10 2l3 4 2-3 3.8 5.067a11 11 0 0 1 2.2 6.6A7.333 7.333 0 0 1 13.667 22h-3.405A7.262 7.262 0 0 1 3 14.738c0-2.423.807-4.776 2.295-6.688Zm7.801 1.411 2-3L17.2 9.267a9 9 0 0 1 1.8 5.4 5.334 5.334 0 0 1-4.826 5.31 3 3 0 0 0 .174-3.748L12 13l-2.348 3.229a3 3 0 0 0 .18 3.754A5.263 5.263 0 0 1 5 14.738c0-1.978.66-3.9 1.873-5.46l3.098-3.983 3.125 4.166Z\"])",
       "hide-vod-muted-segment-popup": ".video-player .muted-segments-alert__scroll-wrapper",
+      "hide-sidebar-sponsored-content": ".side-nav .tw-transition:has(a[class*=\"side-nav-card__link--promoted\"])",
     };
   }
 
@@ -50,7 +51,13 @@ export default class Declutter {
     this.toggleHide("hide-stream-monthly-recap", this.settings.get("addon.trubbel.appearance.declutter.stream.monthly_recap"));
     this.toggleHide("hide-watch-streak", this.settings.get("addon.trubbel.appearance.declutter.stream.watch_streak"));
     this.toggleHide("hide-vod-muted-segment-popup", this.settings.get("addon.trubbel.appearance.declutter.vods.muted_segment_popup"));
+    this.toggleHide("hide-sidebar-sponsored-content", this.settings.get("addon.trubbel.appearance.declutter.vods.muted_segment_popup"));
     this.updateCSS();
+
+    // Appearance - Declutter - Left Navigation - Hide sponsored content
+    this.settings.getChanges("addon.trubbel.appearance.declutter.sidebar.SideNavPromotedFollowedCardComponent", val => {
+      this.loadable.toggle("SideNavPromotedFollowedCardComponent", !val);
+    });
 
     // Appearance - Declutter - Stream - Hide sponsored banner above chat
     this.settings.getChanges("addon.trubbel.appearance.declutter.stream.ChannelSkinsBanner", val => {

--- a/src/trubbel/modules/channel/chat/hide-pinned-message.js
+++ b/src/trubbel/modules/channel/chat/hide-pinned-message.js
@@ -1,0 +1,153 @@
+import { BAD_USERS } from "../../../utilities/constants/types";
+
+export default class AutoHidePinnedMessage {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.router = parent.router;
+    this.site = parent.site;
+    this.log = parent.log;
+
+    this.isActive = false;
+    this.hiddenPinnedIds = new Set();
+
+    this.handleNavigation = this.handleNavigation.bind(this);
+    this.handleSettingChange = this.handleSettingChange.bind(this);
+    this.handlePinnedHighlight = this.handlePinnedHighlight.bind(this);
+    this.hidePinnedHighlight = this.hidePinnedHighlight.bind(this);
+  }
+
+  initialize() {
+    const enabled = this.settings.get("addon.trubbel.channel.chat.hide_pinned_message");
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disable();
+    }
+  }
+
+  handleSettingChange(enabled) {
+    if (enabled) {
+      this.log.info("[AutoHidePinnedMessage] Enabling");
+      this.handleNavigation();
+    } else {
+      this.log.info("[AutoHidePinnedMessage] Disabling");
+      this.disable();
+    }
+  }
+
+  handleNavigation() {
+    this.hiddenPinnedIds.clear();
+
+    const chatRoutes = this.site.constructor.CHAT_ROUTES;
+    const currentRoute = this.router?.current?.name;
+
+    let pathname;
+
+    if (this.router?.match?.[1]) {
+      pathname = this.router.match[1];
+    } else {
+      const segments = this.router?.location?.split("/").filter(s => s.length > 0);
+      pathname = segments?.[0];
+    }
+
+    if (chatRoutes.includes(currentRoute) && pathname && !BAD_USERS.includes(pathname)) {
+      const enabled = this.settings.get("addon.trubbel.channel.chat.hide_pinned_message");
+      if (enabled && !this.isActive) {
+        this.log.info("[AutoHidePinnedMessage] Entering chat page, enabling");
+        this.enable();
+      }
+    } else {
+      if (this.isActive) {
+        this.log.info("[AutoHidePinnedMessage] Leaving chat page, disabling");
+        this.disable();
+      }
+    }
+  }
+  handleNavigation() {
+    this.hiddenPinnedIds.clear();
+
+    const chatRoutes = this.site.constructor.CHAT_ROUTES;
+    const currentRoute = this.router?.current?.name;
+
+    let pathname;
+
+    if (this.router?.match && this.router.match[1]) {
+      pathname = this.router.match[1];
+    } else {
+      const location = this.router?.location;
+      const segment = location?.split("/").filter(segment => segment.length > 0);
+      pathname = segment?.[0];
+    }
+
+    if (chatRoutes.includes(currentRoute) && pathname && !BAD_USERS.includes(pathname)) {
+      const enabled = this.settings.get("addon.trubbel.channel.chat.hide_pinned_message");
+      if (enabled && !this.isActive) {
+        this.enable();
+      }
+    } else {
+      if (this.isActive) {
+        this.disable();
+      }
+    }
+  }
+
+  enable() {
+    if (this.isActive) return;
+    this.isActive = true;
+
+    const ChatContainer = this.site.children.chat.ChatContainer;
+    if (ChatContainer) {
+      ChatContainer.on("mount", this.handlePinnedHighlight, this);
+      ChatContainer.on("update", this.hidePinnedHighlight, this);
+    }
+
+    this.hidePinnedHighlight();
+  }
+
+  disable() {
+    if (!this.isActive) return;
+    this.isActive = false;
+
+    this.hiddenPinnedIds.clear();
+
+    const ChatContainer = this.site.children.chat.ChatContainer;
+    if (ChatContainer) {
+      ChatContainer.off("mount", this.handlePinnedHighlight, this);
+      ChatContainer.off("update", this.hidePinnedHighlight, this);
+    }
+  }
+
+  handlePinnedHighlight() {
+    this.hiddenPinnedIds.clear();
+    this.hidePinnedHighlight();
+  }
+
+  hidePinnedHighlight() {
+    if (!this.isActive) return;
+
+    const site_chat = this.site.children.chat;
+    const highlights = site_chat?.community_stack?.highlights;
+    const dispatch = site_chat?.community_dispatch;
+
+    if (!highlights || !dispatch) return;
+
+    for (const entry of highlights) {
+      if (entry?.event?.type === "pinned_chat") {
+
+        if (this.hiddenPinnedIds.has(entry.id)) {
+          continue;
+        }
+
+        if (!entry?.hidden) {
+          dispatch({
+            type: "hide-highlight",
+            id: entry.id
+          });
+
+          this.hiddenPinnedIds.add(entry.id);
+        }
+      }
+    }
+  }
+}

--- a/src/trubbel/modules/channel/chat/prediction-notifications.js
+++ b/src/trubbel/modules/channel/chat/prediction-notifications.js
@@ -1,0 +1,220 @@
+import { BAD_USERS } from "../../../utilities/constants/types";
+
+export default class PredictionNotifications {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.router = parent.router;
+    this.site = parent.site;
+    this.log = parent.log;
+
+    this.isActive = false;
+
+    this.notifiedPredictions = new Set();
+
+    this.handleNavigation = this.handleNavigation.bind(this);
+    this.enableNotifications = this.enableNotifications.bind(this);
+    this.disableNotifications = this.disableNotifications.bind(this);
+    this.handleSettingChange = this.handleSettingChange.bind(this);
+    this.checkForPredictions = this.checkForPredictions.bind(this);
+  }
+
+  initialize() {
+    const enabled = this.settings.get("addon.trubbel.channel.chat.prediction.notifications");
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disableNotifications();
+    }
+  }
+
+  handleSettingChange(enabled) {
+    if (enabled) {
+      this.log.info("[Prediction Notifications] Enabling");
+      this.handleNavigation();
+    } else {
+      this.log.info("[Prediction Notifications] Disabling");
+      this.disableNotifications();
+    }
+  }
+
+  handleNavigation() {
+    this.notifiedPredictions.clear();
+
+    const chatRoutes = this.site.constructor.CHAT_ROUTES;
+    const currentRoute = this.router?.current?.name;
+
+    let pathname;
+    if (this.router?.match?.[1]) {
+      pathname = this.router.match[1];
+    } else {
+      const segments = this.router?.location?.split("/").filter(s => s.length > 0);
+      pathname = segments?.[0];
+    }
+
+    if (chatRoutes.includes(currentRoute) && pathname && !BAD_USERS.includes(pathname)) {
+      const enabled = this.settings.get("addon.trubbel.channel.chat.prediction.notifications");
+      if (enabled && !this.isActive) {
+        this.log.info("[Prediction Notifications] Entering chat page, enabling");
+        this.enableNotifications();
+      }
+    } else {
+      if (this.isActive) {
+        this.log.info("[Prediction Notifications] Leaving chat page, disabling");
+        this.disableNotifications();
+      }
+    }
+  }
+
+  enableNotifications() {
+    if (this.isActive) return;
+    this.isActive = true;
+
+    const ChatContainer = this.site.children.chat.ChatContainer;
+    if (ChatContainer) {
+      ChatContainer.on("mount", this.checkForPredictions, this);
+      ChatContainer.on("update", this.checkForPredictions, this);
+    }
+
+    this.checkForPredictions();
+  }
+
+  disableNotifications() {
+    if (!this.isActive) return;
+    this.isActive = false;
+
+    const ChatContainer = this.site.children.chat.ChatContainer;
+    if (ChatContainer) {
+      ChatContainer.off("mount", this.checkForPredictions, this);
+      ChatContainer.off("update", this.checkForPredictions, this);
+    }
+  }
+
+  async checkForPredictions() {
+    if (!this.isActive) return;
+
+    const highlights = this.site.children.chat.community_stack?.highlights;
+    if (!highlights) return;
+
+    for (const entry of highlights) {
+      const event = entry?.event;
+
+      if (
+        event?.type === "prediction" &&
+        event?.typeDetails === "prediction_started" &&
+        event?.predictionID &&
+        event?.channelLogin
+      ) {
+        const key = `${event.channelLogin}:${event.predictionID}`;
+        if (this.notifiedPredictions.has(key)) continue;
+
+        this.notifiedPredictions.add(key);
+        this.log.info("[Prediction Notifications] New prediction started:", key);
+        await this.sendNotification(event);
+      }
+    }
+  }
+
+  getPredictionData(predictionID) {
+    const fine = this.parent.resolve("site.fine");
+
+    const elements = document.querySelectorAll(".community-highlight .highlight");
+    if (!elements.length) {
+      this.log.info("[Prediction Notifications] No .community-highlight .highlight elements found");
+      return null;
+    }
+
+    for (const el of elements) {
+      const node = fine.searchNode(
+        fine.getReactInstance(el),
+        n => n?.memoizedProps?.prediction?.id === predictionID,
+        25
+      );
+
+      if (node) {
+        const prediction = node.memoizedProps.prediction;
+        this.log.info("[Prediction Notifications] Found prediction data via fine.searchNode:", prediction);
+        return prediction;
+      }
+    }
+
+    this.log.info("[Prediction Notifications] Could not find prediction data in any .community-highlight .highlight");
+    return null;
+  }
+
+  async requestPermission() {
+    if (!("Notification" in window)) {
+      this.log.info("[Prediction Notifications] Browser does not support notifications");
+      return false;
+    }
+
+    if (Notification.permission === "granted") return true;
+    if (Notification.permission === "denied") return false;
+
+    const result = await Notification.requestPermission();
+    return result === "granted";
+  }
+
+  async sendNotification(event) {
+    this.log.info("[Prediction Notifications] sendNotification event:", event);
+
+    const hasPermission = await this.requestPermission();
+    if (!hasPermission) {
+      this.log.info("[Prediction Notifications] Permission denied, cannot notify");
+      return;
+    }
+
+    // Respect the "only when unfocused" setting
+    const onlyUnfocused = this.settings.get(
+      "addon.trubbel.channel.chat.prediction.notifications.only_unfocused"
+    );
+    if (onlyUnfocused && document.hasFocus()) {
+      this.log.info("[Prediction Notifications] Tab is focused, skipping notification");
+      return;
+    }
+
+    const channel = event.channelLogin;
+    const requireInteraction = this.settings.get(
+      "addon.trubbel.channel.chat.prediction.notifications.require_interaction"
+    );
+
+    const prediction = this.getPredictionData(event.predictionID);
+    const title = prediction?.title ?? "A prediction has started";
+    const outcomes = prediction?.outcomes?.map(o => o.title).join(" vs ") ?? "";
+    const windowSecs = prediction?.predictionWindowSeconds
+      ? ` (${Math.round(prediction.predictionWindowSeconds / 60)} min)`
+      : "";
+
+    const body = [title + windowSecs, outcomes].filter(Boolean).join("\n");
+
+    let icon = "https://www.twitch.tv/favicon.ico";
+    try {
+      const twitch_data = this.parent.resolve("site.twitch_data");
+      const user = twitch_data ? await twitch_data.getUser(null, channel) : null;
+      if (user?.profileImageURL) {
+        icon = user.profileImageURL.replace("50x50", "300x300");
+        this.log.info("[Prediction Notifications] Resolved channel avatar:", icon);
+      }
+    } catch (err) {
+      this.log.info("[Prediction Notifications] Could not resolve channel avatar, using fallback:", err);
+    }
+
+    this.log.info("[Prediction Notifications] Sending notification:", { channel, body, icon });
+
+    try {
+      const notification = new Notification(`Prediction — ${channel}`, {
+        body,
+        icon,
+        tag: `ffz-prediction-${event.predictionID}`,
+        requireInteraction,
+      });
+
+      notification.onclick = () => {
+        window.focus();
+        notification.close();
+      };
+    } catch (err) {
+      this.log.info("[Prediction Notifications] Failed to create notification:", err);
+    }
+  }
+}

--- a/src/trubbel/modules/channel/chat/raid-preview.js
+++ b/src/trubbel/modules/channel/chat/raid-preview.js
@@ -330,10 +330,56 @@ export default class RaidPreview {
       );
     };
 
+    const createUptime = () => {
+      if (!user.stream?.createdAt) return null;
+
+      const { duration_to_string } = FrankerFaceZ.utilities.time;
+      const upSince = new Date(user.stream.createdAt);
+      const uptimeSeconds = Math.floor((Date.now() - upSince.getTime()) / 1000);
+
+      if (uptimeSeconds < 1) return null;
+
+      const uptimeText = duration_to_string(uptimeSeconds, false, false, false, true);
+      const sinceText = this.i18n.formatDateTime(upSince);
+
+      return (
+        <div class="tw-mg-y-05 ffz-uptime-element tw-relative ffz-il-tooltip__container">
+          <div class="tw-border-radius-small tw-c-background-overlay tw-c-text-overlay tw-flex tw-pd-x-05">
+            <div class="tw-flex tw-c-text-live">
+              <figure class="ffz-i-clock" />
+            </div>
+            <p>{uptimeText}</p>
+          </div>
+          <div class="ffz-il-tooltip ffz-il-tooltip--down ffz-il-tooltip--align-right">
+            Stream Uptime
+            <div class="tw-pd-t-05">{sinceText}</div>
+          </div>
+        </div>
+      );
+    };
+
+    const createFlags = () => {
+      if (!this.settings.get("directory.show-flags")) return null;
+      const flags = user.stream?.contentClassificationLabels;
+      if (!flags?.length) return null;
+
+      const tooltipText = "Intended for certain audiences.\nMay contain:\n\n"
+        + flags.map(f => f.localizedName || f.id).join("\n");
+
+      return (
+        <div class="tw-mg-y-05 ffz-flags-element tw-relative ffz-il-tooltip__container">
+          <div class="tw-border-radius-small tw-c-background-overlay tw-c-text-overlay tw-flex tw-pd-x-05">
+            <figure class="ffz-i-flag" />
+          </div>
+          <div class="ffz-il-tooltip ffz-il-tooltip--pre ffz-il-tooltip--down ffz-il-tooltip--align-right">
+            {tooltipText}
+          </div>
+        </div>
+      );
+    };
+
     const createPreviewMedia = () => {
-      if (!user.stream || previewType === 0) {
-        return null;
-      }
+      if (!user.stream || previewType === 0) return null;
 
       const mediaStyle = {
         maxWidth: "440px",
@@ -343,9 +389,18 @@ export default class RaidPreview {
       };
 
       const blurOverlay = createBlurOverlay();
+      const showUptime = this.settings.get("addon.trubbel.channel.chat.raids.previews.uptime");
+      const uptimeEl = showUptime ? createUptime() : null;
+      const flagsEl = showUptime ? createFlags() : null;
+
+      const topRight = (uptimeEl || flagsEl) ? (
+        <div class="tw-absolute tw-mg-1 tw-right-0 tw-top-0 tw-flex tw-flex-column tw-align-items-end">
+          {uptimeEl}
+          {flagsEl}
+        </div>
+      ) : null;
 
       if (previewType === 1) {
-        // Image preview
         return (
           <div class="trubbel-preview-container">
             <img
@@ -355,10 +410,10 @@ export default class RaidPreview {
               style={mediaStyle}
             />
             {blurOverlay}
+            {topRight}
           </div>
         );
       } else if (previewType === 2) {
-        // Video preview
         const params = new URLSearchParams({
           channel: targetLogin,
           enableExtensions: false,
@@ -382,6 +437,7 @@ export default class RaidPreview {
               title={`${targetLogin} Stream Preview`}
             />
             {blurOverlay}
+            {topRight}
           </div>
         );
       }
@@ -541,7 +597,9 @@ export default class RaidPreview {
     };
 
     const previewMedia = createPreviewMedia();
-    const chatSettings = createChatSettings();
+    const chatSettings = this.settings.get("addon.trubbel.channel.chat.raids.previews.chat_settings")
+      ? createChatSettings()
+      : null;
 
     const infoElement = (
       <div class="trubbel-raid-stream-info" style={{ width: "100%", padding: "4px 2px", fontSize: "13px" }}>

--- a/src/trubbel/modules/channel/chat/text-replace.js
+++ b/src/trubbel/modules/channel/chat/text-replace.js
@@ -1,0 +1,114 @@
+import { BAD_USERS } from "../../../utilities/constants/types";
+
+export default class TextReplace {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.router = parent.router;
+    this.style = parent.style;
+    this.chat = parent.chat;
+    this.site = parent.site;
+    this.i18n = parent.i18n;
+
+    this.isActive = false;
+
+    this.handleNavigation = this.handleNavigation.bind(this);
+    this.handleSettingChange = this.handleSettingChange.bind(this);
+    this.enable = this.enable.bind(this);
+    this.disable = this.disable.bind(this);
+  }
+
+  initialize() {
+    const enabled = this.settings.get("addon.trubbel.channel.chat.text_replace");
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disable();
+    }
+  }
+
+  handleSettingChange(enabled) {
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disable();
+    }
+  }
+
+  handleNavigation() {
+    const chatRoutes = this.site.constructor.CHAT_ROUTES;
+    const currentRoute = this.router?.current?.name;
+
+    let pathname;
+
+    if (this.router?.match && this.router.match[1]) {
+      pathname = this.router.match[1];
+    } else {
+      const location = this.router?.location;
+      const segment = location?.split("/").filter(segment => segment.length > 0);
+      pathname = segment?.[0];
+    }
+
+    if (chatRoutes.includes(currentRoute) && pathname && !BAD_USERS.includes(pathname)) {
+      const enabled = this.settings.get("addon.trubbel.channel.chat.text_replace");
+      if (enabled && !this.isActive) {
+        this.enable();
+      }
+    } else {
+      if (this.isActive) {
+        this.disable();
+      }
+    }
+  }
+
+  enable() {
+    if (this.isActive) return;
+
+    this.chat.on("chat:pre-send-message", this.onPreSend, this);
+
+    this.isActive = true;
+  }
+
+  disable() {
+    if (!this.isActive) return;
+
+    this.chat.off("chat:pre-send-message", this.onPreSend, this);
+
+    this.isActive = false;
+  }
+
+  getRules() {
+    return this.settings.provider.get("addon.trubbel.channel.chat.text_replace.rules") ?? [];
+  }
+
+  setRules(rules) {
+    this.settings.provider.set("addon.trubbel.channel.chat.text_replace.rules", rules);
+  }
+
+  applyRules(msg) {
+    const rules = this.getRules();
+
+    for (const rule of rules) {
+      if (!rule.find) continue;
+      if (rule.onlyIfIncludes && !msg.includes(rule.onlyIfIncludes)) continue;
+
+      if (rule.isRegex) {
+        try {
+          msg = msg.replace(new RegExp(rule.find, "g"), rule.replace ?? "");
+        } catch (_) {
+          // invalid regex - skippin
+        }
+      } else {
+        msg = msg.replaceAll(rule.find, rule.replace ?? "");
+      }
+    }
+
+    return msg;
+  }
+
+  onPreSend(event) {
+    if (!this.settings.get("addon.trubbel.channel.chat.text_replace")) return;
+
+    event.message = this.applyRules(event.message);
+  }
+}

--- a/src/trubbel/modules/channel/player/download-clips.js
+++ b/src/trubbel/modules/channel/player/download-clips.js
@@ -1,0 +1,427 @@
+import GET_CLIP from "../../../utilities/graphql/download-clip.gql";
+
+const { createElement, ManagedStyle, on, off, setChildren } = FrankerFaceZ.utilities.dom;
+
+export default class DownloadClips {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.router = parent.router;
+    this.player = parent.player;
+    this.fine = parent.fine;
+    this.site = parent.site;
+    this.log = parent.log;
+
+    this.style = new ManagedStyle;
+    this.isActive = false;
+
+    this._cache = null;
+    this._overlay = null;
+    this._escKey = null;
+
+    this.handleNavigation = this.handleNavigation.bind(this);
+    this.handleSettingChange = this.handleSettingChange.bind(this);
+    this.onPlayerMount = this.onPlayerMount.bind(this);
+    this.onPlayerUpdate = this.onPlayerUpdate.bind(this);
+    this.onPlayerUnmount = this.onPlayerUnmount.bind(this);
+  }
+
+  initialize() {
+    const enabled = this.settings.get("addon.trubbel.channel.player.clip.download");
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disable();
+    }
+  }
+
+  handleSettingChange(enabled) {
+    if (enabled) {
+      this.log.info("[DownloadClips] Enabling");
+      this.handleNavigation();
+    } else {
+      this.log.info("[DownloadClips] Disabling");
+      this.disable();
+    }
+  }
+
+  getSlug() {
+    const match = this.router.match;
+    if (!match) return null;
+    // clips.twitch.tv: /:slug → match[1]
+    // www.twitch.tv:   /:user/clip/:slug → match[2]
+    return this.router.current_name === "clip-page" ? match[1] : match[2];
+  }
+
+  handleNavigation() {
+    const slug = this.getSlug();
+    const enabled = this.settings.get("addon.trubbel.channel.player.clip.download");
+
+    if (slug !== this._cache?.slug) {
+      this._cache = null;
+      this.hidePopup();
+    }
+
+    if (enabled && slug) {
+      if (!this.isActive) {
+        this.log.info("[DownloadClips] Entering clip page, enabling");
+        this.enable();
+      } else {
+        for (const inst of this.player.Player.instances)
+          this.addClipButton(inst);
+      }
+    } else {
+      if (this.isActive) {
+        this.log.info("[DownloadClips] Leaving clip page, disabling");
+        this.disable();
+      }
+    }
+  }
+
+  enable() {
+    if (this.isActive) return;
+    this.isActive = true;
+
+    this.style.set("download-clip", `
+      .trubbel-download-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 9000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.6);
+      }
+      .trubbel-download-popup {
+        width: 360px;
+        border-radius: var(--border-radius-large);
+        box-shadow: var(--shadow-elevation-4);
+        background: var(--color-background-alt);
+        color: var(--color-text-base);
+        border: 1px solid rgba(173, 173, 184, 0.35);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .trubbel-download-popup header {
+        display: flex;
+        align-items: center;
+        padding: 0.5rem 0.75rem;
+        background: var(--color-background-base);
+        border-bottom: 1px solid rgba(173, 173, 184, 0.35);
+        gap: 0.4rem;
+      }
+      .trubbel-download-popup header h3 {
+        flex: 1;
+        margin: 0;
+        font-size: 15px;
+        font-weight: var(--font-weight-semibold);
+      }
+      .trubbel-download-popup .trubbel-popup-body {
+        padding: 0.75rem;
+      }
+    `);
+
+    this.player.Player.on("mount", this.onPlayerMount);
+    this.player.Player.on("update", this.onPlayerUpdate);
+    this.player.Player.on("unmount", this.onPlayerUnmount);
+
+    this.player.Player.ready((cls, instances) => {
+      for (const inst of instances)
+        this.addClipButton(inst);
+    });
+  }
+
+  disable() {
+    if (!this.isActive) return;
+    this.isActive = false;
+
+    this.style.delete("download-clip");
+    this.hidePopup();
+    this._cache = null;
+
+    this.player.Player.off("mount", this.onPlayerMount);
+    this.player.Player.off("update", this.onPlayerUpdate);
+    this.player.Player.off("unmount", this.onPlayerUnmount);
+
+    for (const inst of this.player.Player.instances) {
+      const outer = inst.props.containerRef || this.fine.getChildNode(inst);
+      outer?.querySelector(".ffz--download-clip")?.remove();
+    }
+  }
+
+  onPlayerMount(inst) {
+    this.addClipButton(inst);
+  }
+
+  onPlayerUpdate(inst) {
+    this.addClipButton(inst);
+  }
+
+  onPlayerUnmount(inst) {
+    inst.ffzUninstall?.();
+  }
+
+  addClipButton(inst, tries = 0) {
+    const outer = inst.props.containerRef || this.fine.getChildNode(inst),
+      container = outer && outer.querySelector(this.player.RIGHT_CONTROLS);
+
+    if (!container) {
+      if (tries < 5)
+        return setTimeout(this.addClipButton.bind(this, inst, (tries || 0) + 1), 250);
+      return;
+    }
+
+    let cont = container.querySelector(".ffz--download-clip");
+    if (!this.getSlug()) {
+      if (cont) cont.remove();
+      return;
+    }
+
+    if (!cont) {
+      cont = (<div class="ffz--download-clip" style={{ display: "inline-flex" }}>
+        <div>
+          <button
+            className="ffz-il-tooltip__container"
+            data-a-target="ffz-download-clip-button"
+            aria-label="Download Clip"
+            style={{
+              display: "inline-flex",
+              position: "relative",
+              alignItems: "center",
+              justifyContent: "center",
+              verticalAlign: "middle",
+              overflow: "visible",
+              textDecoration: "none",
+              whiteSpace: "nowrap",
+              userSelect: "none",
+              fontWeight: "var(--font-weight-semibold)",
+              fontSize: "var(--button-text-default)",
+              height: "var(--button-size-default)",
+              width: "var(--button-size-default)",
+              borderRadius: "var(--button-border-radius-default)",
+              border: "none",
+              background: "none",
+              color: "var(--color-fill-button-icon, #53535f)",
+            }}
+            onMouseEnter={(e) => Object.assign(e.currentTarget.style, {
+              backgroundColor: "var(--color-background-button-text-hover, rgba(255, 255, 255, 0.13))",
+              color: "var(--color-fill-button-icon-hover, #fff)"
+            })}
+            onMouseLeave={(e) => Object.assign(e.currentTarget.style, {
+              backgroundColor: "",
+              color: "var(--color-fill-button-icon, #fff)"
+            })}
+            onClick={() => this.handleDownload(inst)}
+          >
+            <div style={{
+              pointerEvents: "none",
+              width: "var(--button-icon-size-default)",
+              height: "var(--button-icon-size-default)",
+              display: "inline-flex",
+              alignItems: "center",
+              fill: "var(--color-fill-current)",
+            }}>
+              <svg width="24" height="24" viewBox="0 0 24 24"
+                focusable="false" aria-hidden="true" role="presentation"
+                style={{ width: "100%", height: "100%" }}>
+                <path d="M13 3v9.586l3.293-3.293 1.414 1.414L12 16.414l-5.707-5.707 1.414-1.414L11 12.586V3h2ZM2 21v-2c2.284 0 20 .055 20 .055V21H2Z" />
+              </svg>
+            </div>
+            <div className="ffz-il-tooltip ffz-il-tooltip--up ffz-il-tooltip--align-center">
+              Download Clip
+            </div>
+          </button>
+        </div>
+      </div>);
+
+      let thing = container.querySelector("button[data-a-target=\"player-settings-button\"]");
+      while (thing?.parentElement && thing.parentElement !== container)
+        thing = thing.parentElement;
+
+      if (thing?.parentElement === container)
+        container.insertBefore(cont, thing);
+      else
+        container.appendChild(cont);
+    }
+  }
+
+  showPopup() {
+    if (this._overlay) return;
+
+    const overlay = (
+      <div class="trubbel-download-overlay" onClick={(e) => {
+        if (e.target === overlay) this.hidePopup();
+      }}>
+        <div class="trubbel-download-popup tw-elevation-3">
+          <header>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M13 3v9.586l3.293-3.293 1.414 1.414L12 16.414l-5.707-5.707 1.414-1.414L11 12.586V3h2ZM2 21v-2c2.284 0 20 .055 20 .055V21H2Z" />
+            </svg>
+            <h3>Download Clip</h3>
+            <button
+              onclick={() => this.hidePopup()}
+              class="tw-button-icon tw-relative ffz-il-tooltip__container"
+            >
+              <span class="tw-button-icon__icon">
+                <figure class="ffz-i-window-close" />
+              </span>
+              <div class="ffz-il-tooltip ffz-il-tooltip--down ffz-il-tooltip--align-right">
+                Close
+              </div>
+            </button>
+          </header>
+          <div class="trubbel-popup-body" data-content="download-qualities">
+            <p style={{ color: "var(--color-text-alt)", fontSize: "13px", textAlign: "center" }}>
+              Loading...
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+
+    this._overlay = overlay;
+
+    const tooltips = this.parent.resolve("tooltips");
+    const container = tooltips?.container ?? document.querySelector("#root") ?? document.body;
+    container.appendChild(this._overlay);
+
+    this._escKey = (e) => { if (e.key === "Escape") this.hidePopup(); };
+    on(document, "keydown", this._escKey);
+  }
+
+  hidePopup() {
+    if (!this._overlay) return;
+
+    if (this._escKey) {
+      off(document, "keydown", this._escKey);
+      this._escKey = null;
+    }
+
+    this._overlay.remove();
+    this._overlay = null;
+  }
+
+  updatePopupContent(clip) {
+    if (!this._overlay) return;
+
+    const content = this._overlay.querySelector("[data-content=\"download-qualities\"]");
+    if (!content) return;
+
+    const { signature, value } = clip.playbackAccessToken;
+
+    const qualities = clip.videoQualities.map(q => ({
+      label: `${q.quality}p${Math.round(q.frameRate) >= 60 ? " 60fps" : ""}`,
+      url: `${q.sourceURL}?sig=${signature}&token=${encodeURIComponent(value)}`,
+    }));
+
+    const children = (
+      <div style={{ width: "100%", overflow: "hidden" }}>
+        <img src={clip.thumbnailURL} alt={clip.title}
+          style={{
+            width: "100%",
+            display: "block",
+            borderRadius: "var(--border-radius-medium)"
+          }}
+        />
+        <div
+          class="tw-relative ffz-tooltip"
+          data-tooltip-type="html"
+          data-title={clip.title}
+          style={{
+            fontSize: "12px",
+            fontWeight: "var(--font-weight-semibold)",
+            color: "var(--color-text-base)",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            padding: "0.4rem 0"
+          }}>
+          {clip.title}
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: `repeat(${qualities.length}, 1fr)`, gap: "0.4rem" }}>
+          {qualities.map(q => (
+            <button
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "0.5rem 0.3rem",
+                borderRadius: "var(--border-radius-medium)",
+                border: "1px solid rgba(173, 173, 184, 0.35)",
+                background: "var(--color-background-base)",
+                color: "var(--color-text-base)",
+                cursor: "pointer",
+                fontSize: "12px",
+                fontWeight: "var(--font-weight-semibold)",
+                gap: "0.3rem"
+              }}
+              onMouseEnter={(e) => Object.assign(e.currentTarget.style, {
+                background: "var(--color-background-button-text-hover)",
+                color: "var(--color-text-button-text-hover)"
+              })}
+              onMouseLeave={(e) => Object.assign(e.currentTarget.style, {
+                background: "var(--color-background-base)",
+                color: "var(--color-text-base)"
+              })}
+              onClick={() => { window.open(q.url, "_blank"); this.hidePopup(); }}
+            >
+              <span>{q.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+
+    setChildren(content, [children]);
+  }
+
+  async handleDownload(inst) {
+    const slug = this.getSlug();
+    if (!slug) {
+      this.log.warn("[DownloadClips] No clip slug found in route");
+      return;
+    }
+
+    if (this._overlay) {
+      this.hidePopup();
+      return;
+    }
+
+    this.showPopup();
+
+    if (this._cache?.slug === slug) {
+      this.updatePopupContent(this._cache.clip);
+      return;
+    }
+
+    try {
+      const apollo = this.parent.resolve("site.apollo");
+      if (!apollo) {
+        this.log.warn("[DownloadClips] Apollo client not available");
+        return;
+      }
+
+      const result = await apollo.client.query({
+        query: GET_CLIP,
+        variables: { slug },
+        fetchPolicy: "network-only"
+      });
+
+      this.log.info("[DownloadClips] result:", result);
+
+      const clip = result?.data?.clip;
+      if (!clip) {
+        this.log.warn("[DownloadClips] No clip data received");
+        return;
+      }
+
+      this._cache = { slug, clip };
+      this.updatePopupContent(clip);
+
+    } catch (error) {
+      this.log.error("[DownloadClips] Error fetching clip:", error);
+    }
+  }
+}

--- a/src/trubbel/modules/channel/vods/click-pause.js
+++ b/src/trubbel/modules/channel/vods/click-pause.js
@@ -1,0 +1,108 @@
+const { createElement } = FrankerFaceZ.utilities.dom;
+
+export default class VODClickPause {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.router = parent.router;
+    this.style = parent.style;
+    this.site = parent.site;
+    this.log = parent.log;
+
+    this.isActive = false;
+
+    this.handleSettingChange = this.handleSettingChange.bind(this);
+    this.handleNavigation = this.handleNavigation.bind(this);
+  }
+
+  initialize() {
+    const enabled = this.settings.get("addon.trubbel.channel.vods.playback.pause");
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disable();
+    }
+  }
+
+  handleSettingChange(enabled) {
+    if (enabled) {
+      this.log.info("[VODClickPause] Enabling");
+      this.handleNavigation();
+    } else {
+      this.log.info("[VODClickPause] Disabling");
+      this.disable();
+    }
+  }
+
+  async handleNavigation() {
+    const currentRoute = this.router?.current?.name;
+    if (currentRoute === "video") {
+      const enabled = this.settings.get("addon.trubbel.channel.vods.playback.pause");
+      if (enabled && !this.isActive) {
+        this.log.info("[VODClickPause] Entering video page, enabling");
+        await this.enable();
+      }
+    } else {
+      if (this.isActive) {
+        this.log.info("[VODClickPause] Leaving video page, disabling");
+        this.disable();
+      }
+    }
+  }
+
+  async enable() {
+    if (this.isActive) return;
+
+    this.log.info("[VODClickPause] Setting up");
+
+    this.site.children.player.Player.on("mount", this.attachListener, this);
+    this.site.children.player.Player.on("update", this.attachListener, this);
+    this.site.children.player.Player.on("unmount", this.detachListener, this);
+
+    for (const inst of this.site.children.player.Player.instances)
+      this.attachListener(inst);
+
+    this.isActive = true;
+  }
+
+  disable() {
+    if (!this.isActive) return;
+
+    this.log.info("[VODClickPause] Disabling");
+
+    for (const inst of this.site.children.player.Player.instances)
+      this.detachListener(inst);
+
+    this.isActive = false;
+  }
+
+  attachListener(inst) {
+    this.detachListener(inst);
+
+    const cont = inst.props.containerRef;
+    if (!cont) return;
+
+    inst._trubbel_vod_click_pause_handler = (event) => {
+      if (!this.settings.get("addon.trubbel.channel.vods.playback.pause")) return;
+
+      const target = event.target;
+      if (!target) return;
+
+      if (
+        target.classList.contains("click-handler") ||
+        target.closest("[data-a-target=\"player-overlay-click-handler\"]")
+      )
+        event.stopPropagation();
+    };
+
+    cont.addEventListener("click", inst._trubbel_vod_click_pause_handler, true);
+  }
+
+  detachListener(inst) {
+    const cont = inst.props.containerRef;
+    if (cont && inst._trubbel_vod_click_pause_handler)
+      cont.removeEventListener("click", inst._trubbel_vod_click_pause_handler, true);
+
+    inst._trubbel_vod_click_pause_handler = null;
+  }
+}

--- a/src/trubbel/modules/inventory/detailed.js
+++ b/src/trubbel/modules/inventory/detailed.js
@@ -1,0 +1,369 @@
+const { createElement, setChildren } = FrankerFaceZ.utilities.dom;
+
+export default class DetailedDrops {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.router = parent.router;
+    this.site = parent.site;
+    this.i18n = parent.i18n;
+    this.log = parent.log;
+
+    this.isActive = false;
+
+    this.handleNavigation = this.handleNavigation.bind(this);
+    this.handleSettingChange = this.handleSettingChange.bind(this);
+  }
+
+  initialize() {
+    const enabled = this.settings.get("addon.trubbel.inventory.drops.detailed");
+    if (enabled) {
+      this.handleNavigation();
+    } else {
+      this.disable();
+    }
+  }
+
+  handleSettingChange(enabled) {
+    if (enabled) {
+      this.log.info("[Detailed Drops] Enabling detailed drops");
+      this.handleNavigation();
+    } else {
+      this.log.info("[Detailed Drops] Disabling detailed drops");
+      this.disable();
+    }
+  }
+
+  handleNavigation() {
+    const currentLocation = this.router?.location;
+    const oldLocation = this.router?.old_location;
+
+    const isCurrentInventory = currentLocation === "/drops/inventory" || currentLocation === "/inventory";
+    const wasInventory = oldLocation === "/drops/inventory" || oldLocation === "/inventory";
+
+    if (isCurrentInventory && this.settings.get("addon.trubbel.inventory.drops.detailed")) {
+      if (!this.isActive) {
+        this.log.info("[Detailed Drops] Entering inventory page, enabling detailed drops");
+        this.enable();
+      }
+    } else if (wasInventory && !isCurrentInventory) {
+      if (this.isActive) {
+        this.log.info("[Detailed Drops] Leaving inventory page");
+        this.isActive = false;
+        this.removeDetailedElements();
+      }
+    }
+  }
+
+  enable() {
+    if (this.isActive) return;
+
+    this.log.info("[Detailed Drops] Setting up detailed drops functionality");
+    this.isActive = true;
+
+    this.setupDetailedDrops();
+  }
+
+  async setupDetailedDrops() {
+    if (!this.isActive) {
+      this.log.info("[Detailed Drops] Not active, skipping setup");
+      return;
+    }
+
+    const currentLocation = this.router?.location;
+    if (currentLocation !== "/drops/inventory" && currentLocation !== "/inventory") {
+      this.log.info("[Detailed Drops] Not on inventory page, skipping setup");
+      return;
+    }
+
+    try {
+      this.log.info("[Detailed Drops] Setting up detailed drops for inventory");
+      const infoElements = await this.waitForElements();
+
+      if (!this.isActive) return;
+
+      const campaignData = this.extractAllCampaignData(infoElements);
+
+      infoElements.forEach((element, index) => {
+        const data = campaignData[index];
+        if (data) this.enhance(element, data);
+      });
+      this.log.info("[Detailed Drops] Successfully set up detailed drops");
+
+      this.enhanceClaimedTimestamps();
+    } catch (error) {
+      this.log.error("[Detailed Drops] Error setting up detailed drops:", error);
+    }
+  }
+
+  extractAllCampaignData(infoElements) {
+    return Array.from(infoElements).map(infoElement => {
+      const parentDiv = infoElement.parentElement;
+      if (!parentDiv) return null;
+
+      const inst = this.site.fine.getReactInstance(parentDiv);
+      if (!inst || !inst.memoizedProps) return null;
+
+      const children = inst.memoizedProps.children;
+      if (!Array.isArray(children) || children.length < 2) return null;
+
+      const descriptionProps = children[0]?.props || {};
+      const rewardsProps = children[1]?.props || {};
+
+      return {
+        description: {
+          campaignID: descriptionProps.campaignID,
+          campaignName: descriptionProps.campaignName,
+          endDate: descriptionProps.endDate,
+          gameSlug: descriptionProps.gameSlug,
+          imageURL: descriptionProps.imageURL,
+          campaignDetailsURL: descriptionProps.campaignDetailsURL,
+          accountLinkURL: descriptionProps.accountLinkURL,
+          isAccountConnected: descriptionProps.isAccountConnected,
+          targetChannels: descriptionProps.targetChannels,
+        },
+        rewards: {
+          campaignID: rewardsProps.campaignID,
+          timeBasedDrops: rewardsProps.timeBasedDrops || [],
+          eventBasedDrops: rewardsProps.eventBasedDrops || [],
+          ownedEventBasedDrops: rewardsProps.ownedEventBasedDrops || [],
+        }
+      };
+    }).filter(Boolean);
+  }
+
+  async waitForElements() {
+    let timeoutId;
+    let animFrameId;
+
+    return new Promise((resolve, reject) => {
+      timeoutId = setTimeout(() => {
+        cancelAnimationFrame(animFrameId);
+        this.log.warn("[Detailed Drops] Timeout waiting for inventory elements");
+        reject(new Error("[Detailed Drops] Timeout waiting for inventory elements"));
+      }, 10000);
+
+      const checkElements = () => {
+        const elements = document.querySelectorAll(".inventory-campaign-info");
+        if (elements.length > 0) {
+          clearTimeout(timeoutId);
+          this.log.info(`[Detailed Drops] Found ${elements.length} inventory elements`);
+          resolve(elements);
+        } else {
+          animFrameId = requestAnimationFrame(checkElements);
+        }
+      };
+      animFrameId = requestAnimationFrame(checkElements);
+    });
+  }
+
+  disable() {
+    if (!this.isActive) return;
+
+    this.log.info("[Detailed Drops] Removing detailed drops functionality");
+    this.isActive = false;
+
+    this.removeDetailedElements();
+  }
+
+  removeDetailedElements() {
+    const injectedDivs = document.querySelectorAll("[data-trubbel-drops-dates]");
+    injectedDivs.forEach(div => {
+      const pElement = div.parentElement;
+      if (pElement) {
+        pElement.querySelectorAll("span").forEach(span => span.style.display = "");
+      }
+      div.remove();
+    });
+
+    const replacedProgress = document.querySelectorAll("[data-trubbel-progress-replaced]");
+    replacedProgress.forEach(el => delete el.dataset.trubbelProgressReplaced);
+
+    const timestamped = document.querySelectorAll("[data-trubbel-timestamp]");
+    timestamped.forEach(p => {
+      p.classList.remove("tw-relative", "ffz-tooltip", "ffz-tooltip--no-mouse");
+      delete p.dataset.title;
+      delete p.dataset.tooltipType;
+      delete p.dataset.trubbelTimestamp;
+    });
+  }
+
+  enhance(infoElement, campaignData) {
+    if (!this.isActive) return;
+
+    this.replaceDateInfo(infoElement, campaignData);
+    this.replaceProgressText(infoElement, campaignData);
+  }
+
+  replaceDateInfo(infoElement, campaignData) {
+    if (!campaignData) return;
+
+    const dateSpans = infoElement.querySelectorAll("div p span");
+    if (!dateSpans.length) return;
+
+    const pElement = dateSpans[0].parentElement;
+
+    const startDate = campaignData.rewards?.timeBasedDrops?.[0]?.startAt;
+    const endDate = campaignData.description?.endDate;
+
+    if (!startDate && !endDate) return;
+
+    if (pElement.querySelector("[data-trubbel-drops-dates]")) return;
+
+    const formattedStartDate = this.i18n.formatDateTime(startDate, "full");
+    const formattedEndDate = this.i18n.formatDateTime(endDate, "full");
+
+    dateSpans.forEach(span => span.style.display = "none");
+
+    pElement.appendChild(
+      <div
+        data-trubbel-drops-dates
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.4rem"
+        }}
+      >
+        <div
+          className="tw-relative ffz-tooltip ffz-tooltip--no-mouse"
+          data-title={`<span style="font-size:var(--font-size-base);"><strong>Start Date:</strong> ${this.i18n.toRelativeTime(startDate)}</span>`}
+          data-tooltip-type="html"
+          style={{ display: "flex", flexDirection: "column" }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", fontSize: "var(--deprecated-font-size-7)" }}>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: "0" }}>
+              <path fill-rule="evenodd" d="M8 2H6v2H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-2V2h-2v2H8V2Zm12 6H4v12h16V8Z" clip-rule="evenodd" />
+              <path fill-rule="evenodd" d="M7 11h2v2H7v-2Z" clip-rule="evenodd" />
+            </svg>
+            <strong>Start Date:</strong>
+          </div>
+          <span style={{ color: "var(--color-text-alt-2)", fontSize: "var(--deprecated-font-size-7)" }}>{formattedStartDate}</span>
+        </div>
+        <div
+          className="tw-relative ffz-tooltip ffz-tooltip--no-mouse"
+          data-title={`<span style="font-size:var(--font-size-base);"><strong>End Date:</strong> ${this.i18n.toRelativeTime(endDate)}</span>`}
+          data-tooltip-type="html"
+          style={{ display: "flex", flexDirection: "column" }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", fontSize: "var(--deprecated-font-size-7)" }}>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: "0" }}>
+              <path fill-rule="evenodd" d="M8 2H6v2H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-2V2h-2v2H8V2Zm12 6H4v12h16V8Z" clip-rule="evenodd" />
+              <path fill-rule="evenodd" d="M15 15h2v2h-2v-2Z" clip-rule="evenodd" />
+            </svg>
+            <strong>End Date:</strong>
+          </div>
+          <span style={{ color: "var(--color-text-alt-2)", fontSize: "var(--deprecated-font-size-7)" }}>{formattedEndDate}</span>
+        </div>
+      </div>
+    );
+  }
+
+  replaceProgressText(infoElement, campaignData) {
+    const drops = campaignData?.rewards?.timeBasedDrops;
+    if (!drops?.length) return;
+
+    const parentElement = infoElement.parentElement;
+    if (!parentElement) return;
+
+    const benefitNameToDropMap = new Map();
+    for (const drop of drops) {
+      for (const edge of (drop.benefitEdges || [])) {
+        if (edge.benefit?.name) {
+          benefitNameToDropMap.set(edge.benefit.name, drop);
+        }
+      }
+    }
+
+    const formatMinutes = (mins) => {
+      if (mins >= 60) {
+        const h = Math.floor(mins / 60);
+        const m = mins % 60;
+        return m > 0 ? `${h}h ${m}m` : `${h}h`;
+      }
+      return `${mins}m`;
+    };
+
+    const progressBars = parentElement.querySelectorAll("[role=\"progressbar\"]");
+
+    progressBars.forEach((progressBar) => {
+      const cardContainer = progressBar.parentElement?.parentElement;
+      if (!cardContainer) return;
+
+      const nameText = cardContainer.querySelector("p")?.textContent?.trim();
+      if (!nameText) return;
+
+      const drop = benefitNameToDropMap.get(nameText);
+      if (!drop) return;
+
+      const progressTextP = progressBar.nextElementSibling?.querySelector("p");
+      if (!progressTextP || progressTextP.dataset.trubbelProgressReplaced) return;
+
+      progressTextP.dataset.trubbelProgressReplaced = "true";
+
+      const current = drop.self?.currentMinutesWatched ?? 0;
+      const required = drop.requiredMinutesWatched ?? 0;
+      const isClaimed = drop.self?.isClaimed ?? false;
+      const displayCurrent = Math.min(current, required);
+      const remaining = Math.max(0, required - current);
+
+      const tooltipContent = isClaimed
+        ? `<span style="font-size:var(--font-size-base);"><strong>Claimed</strong> · watched ${formatMinutes(displayCurrent)} of ${formatMinutes(required)}</span>`
+        : `<span style="font-size:var(--font-size-base);">${formatMinutes(remaining)} remaining</span>`;
+
+      setChildren(progressTextP, [
+        <span
+          className="tw-relative ffz-tooltip ffz-tooltip--no-mouse"
+          data-title={tooltipContent}
+          data-tooltip-type="html"
+          style={{ display: "inline-flex", alignItems: "center", gap: "0.2rem" }}
+        >
+          <span style={{ color: "var(--color-text-base)" }}>{formatMinutes(displayCurrent)}</span>
+          <span style={{ color: "var(--color-text-alt-2)" }}>/</span>
+          <span>{formatMinutes(required)}</span>
+          {isClaimed && (
+            <span style={{ color: "var(--color-fill-live)", marginLeft: "0.3rem" }}>✓</span>
+          )}
+        </span>
+      ]);
+    });
+  }
+
+  enhanceClaimedTimestamps() {
+    const towers = document.querySelectorAll(".drops-root__content .inventory-page .tw-tower");
+    for (const tower of towers) {
+      if (tower.closest(".inventory-campaign-info")) continue;
+      this._enhanceTowerTimestamps(tower);
+    }
+  }
+
+  _enhanceTowerTimestamps(tower) {
+    const inst = this.site.fine.getReactInstance(tower);
+    const children = inst?.memoizedProps?.children;
+    if (!Array.isArray(children) || !Array.isArray(children[0])) return;
+
+    const dropElements = children[0];
+
+    const cardNodes = [];
+    for (const child of tower.children) {
+      if (child.querySelector("img.inventory-drop-image"))
+        cardNodes.push(child);
+    }
+
+    for (let i = 0; i < cardNodes.length && i < dropElements.length; i++) {
+      const card = cardNodes[i];
+      const drop = dropElements[i]?.props?.awardedDrop;
+      if (!drop?.awardedAt) continue;
+
+      const paragraphs = card.querySelectorAll("p");
+      for (const p of paragraphs) {
+        const text = p.textContent?.trim();
+        if (text && text !== drop.awardedDropName && !p.dataset.trubbelTimestamp) {
+          p.dataset.trubbelTimestamp = "true";
+          p.classList.add("tw-relative", "ffz-tooltip", "ffz-tooltip--no-mouse");
+          p.dataset.title = this.i18n.formatDateTime(drop.awardedAt, "full");
+          break;
+        }
+      }
+    }
+  }
+}

--- a/src/trubbel/modules/twilight/experiments/eppo.js
+++ b/src/trubbel/modules/twilight/experiments/eppo.js
@@ -1,0 +1,301 @@
+import { EPPO_OVERRIDES_KEY_CONFIG } from "../../../utilities/constants/config";
+
+export class EppoManager {
+  constructor(parent) {
+    this.parent = parent;
+    this.settings = parent.settings;
+    this.site = parent.site;
+    this.log = parent.log;
+
+    this._cache = new Map();
+
+    this._hookEppoConfig();
+  }
+
+  initialize() {
+    this._applyOverridesToExistingConfig();
+
+    this.log.info("[Eppo Manager] Initialized with config hook active");
+  }
+
+  _hookEppoConfig() {
+    const self = this;
+    const existing = window.__setEppoConfig;
+
+    function wrapFn(fn) {
+      return (config) => {
+        self.log.info("[Eppo Manager] Intercepted Eppo config reload, injecting overrides...");
+        const modified = self._injectOverridesIntoConfig(config);
+        fn(modified);
+        self._cache.clear();
+      };
+    }
+
+    Object.defineProperty(window, "__setEppoConfig", {
+      configurable: true,
+      get() {
+        return undefined;
+      },
+      set(fn) {
+        Object.defineProperty(window, "__setEppoConfig", {
+          configurable: true,
+          writable: true,
+          value: wrapFn(fn),
+        });
+      },
+    });
+
+    if (existing) {
+      window.__setEppoConfig = existing;
+    }
+
+    this.log.info("[Eppo Manager] Hooked __setEppoConfig to inject overrides");
+  }
+
+  _applyOverridesToExistingConfig() {
+    if (!window.__eppoConfig) {
+      this.log.warn("[Eppo Manager] No existing Eppo config found");
+      return;
+    }
+
+    const overrides = this._getOverrides();
+    if (!Object.keys(overrides).length) {
+      this.log.info("[Eppo Manager] No overrides to apply");
+      return;
+    }
+
+    this.log.info("[Eppo Manager] Applying overrides to existing config...");
+    this._injectOverridesIntoConfig(window.__eppoConfig);
+    this.log.info(`[Eppo Manager] Applied ${Object.keys(overrides).length} overrides to existing config`);
+  }
+
+  _injectOverridesIntoConfig(config) {
+    if (!config?.flags) return config;
+
+    const overrides = this._getOverrides();
+    if (!Object.keys(overrides).length) return config;
+
+    for (const [flagKey, overrideValue] of Object.entries(overrides)) {
+      this._injectOverrideForKey(config, flagKey, overrideValue);
+    }
+
+    return config;
+  }
+
+  _injectOverrideForKey(config, flagKey, overrideValue) {
+    if (!config?.flags) return;
+
+    const flag = config.flags[flagKey];
+    if (!flag) {
+      this.log.warn(`[Eppo Manager] Flag ${flagKey} not found in config`);
+      return;
+    }
+
+    flag.allocations = flag.allocations.filter(
+      (a) => a.key !== `ffz-override-${flagKey}`
+    );
+
+    if (overrideValue === undefined) return;
+
+    let targetVariationKey = null;
+    for (const [varKey, varData] of Object.entries(flag.variations)) {
+      if (varData.value === overrideValue) {
+        targetVariationKey = varKey;
+        break;
+      }
+    }
+
+    if (!targetVariationKey) {
+      this.log.warn(
+        `[Eppo Manager] No variation matches override value for ${flagKey}:`,
+        overrideValue
+      );
+      return;
+    }
+
+    flag.allocations.unshift({
+      key: `ffz-override-${flagKey}`,
+      startAt: new Date(0).toISOString(),
+      endAt: "9999-12-31T00:00:00.000Z",
+      splits: [{ variationKey: targetVariationKey, shards: [] }],
+      doLog: false,
+    });
+
+    this.log.info(
+      `[Eppo Manager] Injected override for ${flagKey} = ${overrideValue} (variation: ${targetVariationKey})`
+    );
+  }
+
+  getEppoFlags() {
+    return window.__eppoConfig?.flags ?? {};
+  }
+
+  getFlag(key) {
+    return this.getEppoFlags()[key] ?? null;
+  }
+
+  getAssignment(key) {
+    if (this._cache.has(key)) return this._cache.get(key);
+
+    const value = this._computeAssignment(key);
+    this._cache.set(key, value);
+    return value;
+  }
+
+  _computeAssignment(key) {
+    const overrides = this._getOverrides();
+    if (overrides[key] !== undefined) return overrides[key];
+
+    const flag = this.getFlag(key);
+    if (!flag || !flag.enabled) return null;
+
+    for (const allocation of flag.allocations ?? []) {
+      for (const split of allocation.splits ?? []) {
+        if (!split.shards || split.shards.length === 0) {
+          const variation = flag.variations[split.variationKey];
+          return variation ? variation.value : split.variationKey;
+        }
+      }
+    }
+
+    const firstKey = Object.keys(flag.variations ?? {})[0];
+    if (firstKey) {
+      const variation = flag.variations[firstKey];
+      return variation ? variation.value : firstKey;
+    }
+
+    return null;
+  }
+
+  _invalidateKey(key) {
+    this._cache.delete(key);
+  }
+
+  getVariationType(key) {
+    return this.getFlag(key)?.variationType ?? null;
+  }
+
+  getVariations(key) {
+    const flag = this.getFlag(key);
+    if (!flag?.variations) return [];
+
+    return Object.entries(flag.variations).map(([varKey, varData]) => ({
+      key: varKey,
+      value: varData.value,
+    }));
+  }
+
+  hasOverride(key) {
+    const overrides = this._getOverrides();
+    return overrides[key] !== undefined;
+  }
+
+  setOverride(key, value) {
+    const overrides = this._getOverrides();
+
+    const variationType = this.getVariationType(key);
+    const parsedValue = this._parseValueByType(value, variationType);
+
+    overrides[key] = parsedValue;
+    this._saveOverrides(overrides);
+
+    if (window.__eppoConfig) {
+      this._injectOverrideForKey(window.__eppoConfig, key, parsedValue);
+    }
+
+    this._invalidateKey(key);
+    const newValue = this.getAssignment(key);
+
+    this.log.info(`[Eppo Manager] Override set: ${key} = ${parsedValue}`);
+    this.log.warn("[Eppo Manager] May need to refresh for some features to update.");
+
+    this.parent.emit(`:eppo-changed:${key}`, newValue);
+    this.parent.emit(":eppo-changed", key, newValue);
+  }
+
+  deleteOverride(key) {
+    const overrides = this._getOverrides();
+    if (overrides[key] === undefined) return;
+
+    delete overrides[key];
+    this._saveOverrides(overrides);
+
+    if (window.__eppoConfig) {
+      this._injectOverrideForKey(window.__eppoConfig, key, undefined);
+    }
+
+    this._invalidateKey(key);
+    const newValue = this.getAssignment(key);
+
+    this.log.info(`[Eppo Manager] Override deleted: ${key}`);
+    this.log.warn("[Eppo Manager] May need to refresh for some features to update.");
+
+    this.parent.emit(`:eppo-changed:${key}`, newValue);
+    this.parent.emit(":eppo-changed", key, newValue);
+  }
+
+  _parseValueByType(value, variationType) {
+    switch (variationType) {
+      case "BOOLEAN":
+        return value === true || value === "true";
+
+      case "INTEGER":
+        return parseInt(value, 10);
+
+      case "JSON":
+        if (typeof value === "string") {
+          try {
+            return JSON.parse(value);
+          } catch (e) {
+            this.log.warn("[Eppo Manager] Invalid JSON value:", value);
+            return value;
+          }
+        }
+        return value;
+
+      case "STRING":
+      default:
+        return String(value);
+    }
+  }
+
+  _getOverrides() {
+    try {
+      return this.settings.provider.get(EPPO_OVERRIDES_KEY_CONFIG) ?? {};
+    } catch (e) {
+      this.log.error("[Eppo Manager] Error loading overrides:", e);
+      return {};
+    }
+  }
+
+  _saveOverrides(overrides) {
+    try {
+      if (!overrides || !Object.keys(overrides).length) {
+        this.settings.provider.delete(EPPO_OVERRIDES_KEY_CONFIG);
+      } else {
+        this.settings.provider.set(EPPO_OVERRIDES_KEY_CONFIG, overrides);
+      }
+    } catch (e) {
+      this.log.error("[Eppo Manager] Error saving overrides:", e);
+    }
+  }
+
+  generateLog() {
+    const out = ["Eppo Flags:", ""];
+    const flags = this.getEppoFlags();
+
+    for (const [key, flag] of Object.entries(flags)) {
+      if (!flag.enabled) continue;
+
+      const assignment = this.getAssignment(key);
+      const hasOverride = this.hasOverride(key);
+      const type = flag.variationType;
+
+      out.push(
+        `${key}: ${assignment}${hasOverride ? " (Override)" : ""} (type: ${type})`
+      );
+    }
+
+    return out.join("\n");
+  }
+}

--- a/src/trubbel/modules/twilight/sidebar/pinned.js
+++ b/src/trubbel/modules/twilight/sidebar/pinned.js
@@ -443,7 +443,7 @@ export class SidebarPinned {
       return (
         <div
           aria-label="Pinned Channels"
-          className="side-nav-section trubbel-pinned-channels-section"
+          className="trubbel-pinned-channels-section"
           role="group"
         >
           <div
@@ -510,7 +510,7 @@ export class SidebarPinned {
       return (
         <div
           aria-label="Pinned Channels"
-          className="side-nav-section trubbel-pinned-channels-section"
+          className="trubbel-pinned-channels-section"
           role="group"
         >
           <div

--- a/src/trubbel/settings/appearance/declutter.js
+++ b/src/trubbel/settings/appearance/declutter.js
@@ -177,6 +177,19 @@ export class Appearance_Declutter extends FrankerFaceZ.utilities.module.Module {
       changed: val => this.declutter.toggleHide("hide-sidebar-gift-discount", val)
     });
 
+    // Appearance - Declutter - Left Navigation - Hide sponsored content
+    this.settings.add("addon.trubbel.appearance.declutter.sidebar.SideNavPromotedFollowedCardComponent", {
+      default: false,
+      ui: {
+        sort: 11,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Appearance > Declutter >> Left Navigation",
+        title: "Hide sponsored content",
+        description: "This will prevent any promoted streams from showing up at all in the sidebar.",
+        component: "setting-check-box"
+      },
+      changed: val => this.declutter.toggleHide("hide-sidebar-sponsored-content", val)
+    });
+
 
 
     // Appearance - Declutter - Player - Hide the "Closed Captions"-button within the settings menu

--- a/src/trubbel/settings/channel/chat.js
+++ b/src/trubbel/settings/channel/chat.js
@@ -1,3 +1,4 @@
+import AutoHidePinnedMessage from "../../modules/channel/chat/hide-pinned-message";
 import BTTVModeration from "../../modules/channel/chat/bttv";
 import ChatTranslate from "../../modules/channel/chat/translate";
 import Commands from "../../modules/channel/chat/commands-handler";
@@ -8,12 +9,14 @@ import MessageHighlight from "../../modules/channel/chat/message-highlight";
 import OldClipFormat from "../../modules/channel/chat/old-clip-format";
 import OldViewerList from "../../modules/channel/chat/old-viewer-list";
 import PopoutChatName from "../../modules/channel/chat/popout-header-name";
+import PredictionNotifications from "../../modules/channel/chat/prediction-notifications";
 import RaidMessage from "../../modules/channel/chat/raid-message";
 import RaidPreview from "../../modules/channel/chat/raid-preview";
 import RecentMessages from "../../modules/channel/chat/recent-messages";
 import SharedChatMessage from "../../modules/channel/chat/shared-chat";
 import SteamInspect from "../../modules/channel/chat/steam-inspect";
 import StopEmoteAnimate from "../../modules/channel/chat/stop-emote-animate";
+import TextReplace from "../../modules/channel/chat/text-replace";
 import TimestampHandler from "../../modules/channel/chat/timestamps";
 
 const { createElement, ManagedStyle } = FrankerFaceZ.utilities.dom;
@@ -34,6 +37,7 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
     this.inject("site.twitch_data");
     this.inject("site.chat.scroller");
 
+    this.autoHidePinnedMessage = new AutoHidePinnedMessage(this);
     this.bttvModeration = new BTTVModeration(this);
     this.chatTranslate = new ChatTranslate(this);
     this.customCommands = new Commands(this);
@@ -44,12 +48,14 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
     this.oldClipFormat = new OldClipFormat(this);
     this.oldViewerList = new OldViewerList(this);
     this.popoutChatName = new PopoutChatName(this);
+    this.predictionNotifications = new PredictionNotifications(this);
     this.raidMessage = new RaidMessage(this);
     this.raidPreview = new RaidPreview(this);
     this.recentMessages = new RecentMessages(this);
     this.sharedChatMessage = new SharedChatMessage(this);
     this.steamInspect = new SteamInspect(this);
     this.stopEmoteAnimate = new StopEmoteAnimate(this);
+    this.textReplace = new TextReplace(this);
     this.timestampHandler = new TimestampHandler(this);
 
     // Channel - Chat - Accessibility - Enable Animated Emotes Blocklist
@@ -301,6 +307,20 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
 
 
 
+    // Channel - Chat - Pinned Message - Auto-hide pinned messages
+    this.settings.add("addon.trubbel.channel.chat.hide_pinned_message", {
+      default: false,
+      ui: {
+        sort: 0,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Pinned Messages",
+        title: "Auto-hide Pinned Messages",
+        component: "setting-check-box"
+      },
+      changed: val => this.autoHidePinnedMessage.handleSettingChange(val)
+    });
+
+
+
     // Channel - Chat - Popout - Display channel name in Popout Chat
     this.settings.add("addon.trubbel.channel.chat.popout.title_name", {
       default: false,
@@ -316,6 +336,57 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
 
 
 
+    // Channel - Chat - Predictions - Prediction Started Notifications
+    this.settings.add("addon.trubbel.channel.chat.prediction.notifications", {
+      default: false,
+      ui: {
+        sort: 0,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Predictions",
+        title: "Prediction Started Notifications",
+        description:
+          "Send a browser notification when a prediction starts in the current channel.\n\n" +
+          "**Note:** Your browser will ask for notification permission the first time you enable this.",
+        component: "setting-check-box"
+      },
+      changed: val => this.predictionNotifications.handleSettingChange(val)
+    });
+
+    // Channel - Chat - Predictions - Only notify when tab is unfocused
+    this.settings.add("addon.trubbel.channel.chat.prediction.notifications.only_unfocused", {
+      default: true,
+      requires: ["addon.trubbel.channel.chat.prediction.notifications"],
+      process(ctx, val) {
+        if (!ctx.get("addon.trubbel.channel.chat.prediction.notifications")) return false;
+        return val;
+      },
+      ui: {
+        sort: 1,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Predictions",
+        title: "Only notify when tab is unfocused",
+        description: "Skip the notification if you already have the Twitch tab in focus.",
+        component: "setting-check-box"
+      }
+    });
+
+    // Channel - Chat - Predictions - Keep notification until dismissed
+    this.settings.add("addon.trubbel.channel.chat.prediction.notifications.require_interaction", {
+      default: false,
+      requires: ["addon.trubbel.channel.chat.prediction.notifications"],
+      process(ctx, val) {
+        if (!ctx.get("addon.trubbel.channel.chat.prediction.notifications")) return false;
+        return val;
+      },
+      ui: {
+        sort: 2,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Predictions",
+        title: "Keep notification until dismissed",
+        description: "Prevent the notification from auto-dismissing, it will stay visible until you explicitly close it.\n\n**Note:** Behaviour may vary depending on your browser and OS.",
+        component: "setting-check-box"
+      }
+    });
+
+
+
     // Channel - Chat - Raids - Show raid preview
     this.settings.add("addon.trubbel.channel.chat.raids.previews", {
       default: 0,
@@ -323,7 +394,7 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
         sort: 0,
         path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Raids",
         title: "Show raid preview",
-        description: "Display additional information when a raid is active, category, amount of viewers and preview media.",
+        description: "Display an image or video preview of the stream when a raid is active.",
         component: "setting-select-box",
         data: [
           { value: 0, title: "Off" },
@@ -332,6 +403,42 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
         ]
       },
       changed: val => this.raidPreview.handleSettingChange(val)
+    });
+
+    // Channel - Chat - Raids - Show uptime on raid preview
+    this.settings.add("addon.trubbel.channel.chat.raids.previews.uptime", {
+      default: true,
+      requires: ["addon.trubbel.channel.chat.raids.previews"],
+      process(ctx, val) {
+        if (!ctx.get("addon.trubbel.channel.chat.raids.previews"))
+          return false;
+        return val;
+      },
+      ui: {
+        sort: 1,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Raids",
+        title: "Show uptime on raid preview",
+        description: "Display the stream uptime (and content flags if enabled in FFZ settings) on the preview.",
+        component: "setting-check-box"
+      }
+    });
+
+    // Channel - Chat - Raids - Show chat restrictions on raid preview
+    this.settings.add("addon.trubbel.channel.chat.raids.previews.chat_settings", {
+      default: true,
+      requires: ["addon.trubbel.channel.chat.raids.previews"],
+      process(ctx, val) {
+        if (!ctx.get("addon.trubbel.channel.chat.raids.previews"))
+          return false;
+        return val;
+      },
+      ui: {
+        sort: 2,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Raids",
+        title: "Show chat restrictions on raid preview",
+        description: "Display chat restrictions (sub-only, followers-only, slow mode, etc.) below the preview.",
+        component: "setting-check-box"
+      }
     });
 
 
@@ -346,6 +453,30 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
         component: "setting-check-box"
       },
       changed: val => this.sharedChatMessage.handleSettingChange(val)
+    });
+
+
+
+    // Channel - Chat - Text Replace - Enable text replacement for outgoing messages
+    this.settings.add("addon.trubbel.channel.chat.text_replace", {
+      default: false,
+      ui: {
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Text Replace",
+        title: "Enable text replacement for outgoing messages.",
+        component: "setting-check-box"
+      }
+    });
+
+    this.settings.add("addon.trubbel.channel.chat.text_replace.rules", {
+      default: [],
+    });
+
+    this.settings.addUI("addon.trubbel.channel.chat.text_replace.rules-editor", {
+      path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Chat >> Text Replace @{\"profile_warning\": false}",
+      component: () => import("../../components/main_menu/text-replace.vue"),
+      force_seen: true,
+      getRules: () => this.textReplace.getRules(),
+      setRules: (rules) => this.textReplace.setRules(rules),
     });
 
 
@@ -477,6 +608,7 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
 
   onEnable() {
     this.router.on(":route", this.navigate, this);
+    this.autoHidePinnedMessage.initialize();
     this.bttvModeration.initialize();
     this.chatTranslate.initialize();
     this.customCommands.initialize();
@@ -487,16 +619,19 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
     this.oldClipFormat.initialize();
     this.oldViewerList.initialize();
     this.popoutChatName.initialize();
+    this.predictionNotifications.initialize();
     this.raidMessage.initialize();
     this.raidPreview.initialize();
     this.recentMessages.initialize();
     this.sharedChatMessage.initialize();
     this.steamInspect.initialize();
     this.stopEmoteAnimate.initialize();
+    this.textReplace.initialize();
     this.timestampHandler.initialize();
   }
 
   async navigate() {
+    this.autoHidePinnedMessage.handleNavigation();
     this.bttvModeration.handleNavigation();
     this.chatTranslate.handleNavigation();
     this.customCommands.handleNavigation();
@@ -507,12 +642,14 @@ export class Channel_Chat extends FrankerFaceZ.utilities.module.Module {
     this.oldClipFormat.handleNavigation();
     this.oldViewerList.handleNavigation();
     this.popoutChatName.handleNavigation();
+    this.predictionNotifications.handleNavigation();
     this.raidMessage.handleNavigation();
     this.raidPreview.handleNavigation();
     this.recentMessages.handleNavigation();
     this.sharedChatMessage.handleNavigation();
     this.steamInspect.handleNavigation();
     this.stopEmoteAnimate.handleNavigation();
+    this.textReplace.handleNavigation();
     this.timestampHandler.handleNavigation();
   }
 }

--- a/src/trubbel/settings/channel/vods.js
+++ b/src/trubbel/settings/channel/vods.js
@@ -1,4 +1,5 @@
 import AutoSkipMutedSegments from "../../modules/channel/vods/auto-skip-muted-segments";
+import VODClickPause from "../../modules/channel/vods/click-pause";
 import CustomSeeking from "../../modules/channel/vods/custom-seeking";
 import ProgressBar from "../../modules/channel/vods/progress-bar";
 
@@ -15,8 +16,23 @@ export class Channel_VODs extends FrankerFaceZ.utilities.module.Module {
     this.inject("site.router");
 
     this.autoSkipMutedSegments = new AutoSkipMutedSegments(this);
+    this.vodClickPause = new VODClickPause(this);
     this.customSeeking = new CustomSeeking(this);
     this.progressBar = new ProgressBar(this);
+
+    // Channel - VODs - Playback - Disable click-to-pause on VODs
+    this.settings.add("addon.trubbel.channel.vods.playback.pause", {
+      default: false,
+      ui: {
+        sort: 0,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > VODs >> Playback",
+        title: "Disable click-to-pause on VODs",
+        component: "setting-check-box"
+      },
+      changed: val => this.vodClickPause.handleSettingChange(val)
+    });
+
+
 
     // Channel - VODs - Progress Bar - Enable Custom Progress Bar
     this.settings.add("addon.trubbel.channel.vods.progress_bar", {
@@ -128,12 +144,14 @@ export class Channel_VODs extends FrankerFaceZ.utilities.module.Module {
   onEnable() {
     this.router.on(":route", this.navigate, this);
     this.autoSkipMutedSegments.initialize();
+    this.vodClickPause.initialize();
     this.customSeeking.initialize();
     this.progressBar.initialize();
   }
 
   async navigate() {
     this.autoSkipMutedSegments.handleNavigation();
+    this.vodClickPause.handleNavigation();
     this.customSeeking.handleNavigation();
     this.progressBar.handleNavigation();
   }

--- a/src/trubbel/settings/inventory/drops.js
+++ b/src/trubbel/settings/inventory/drops.js
@@ -1,5 +1,6 @@
 import AutoClaimDrops from "../../modules/inventory/claim";
 import CollapsibleDrops from "../../modules/inventory/collapsible";
+import DetailedDrops from "../../modules/inventory/detailed";
 
 const { ManagedStyle } = FrankerFaceZ.utilities.dom;
 
@@ -11,10 +12,12 @@ export class Inventory_Drops extends FrankerFaceZ.utilities.module.Module {
 
     this.inject("settings");
     this.inject("site");
+    this.inject("i18n");
     this.inject("site.router");
 
     this.autoClaimDrops = new AutoClaimDrops(this);
     this.collapsibleDrops = new CollapsibleDrops(this);
+    this.detailedDrops = new DetailedDrops(this);
 
     // Inventory - Drops - Claim - Enable auto claim
     this.settings.add("addon.trubbel.inventory.drops.claim", {
@@ -64,15 +67,32 @@ export class Inventory_Drops extends FrankerFaceZ.utilities.module.Module {
       },
       changed: val => this.collapsibleDrops.handleSettingChange(val)
     });
+
+
+
+    // Inventory - Drops - Progress - Display detailed drops information
+    this.settings.add("addon.trubbel.inventory.drops.detailed", {
+      default: false,
+      ui: {
+        sort: 0,
+        path: "Add-Ons > Trubbel\u2019s Utilities > Inventory > Drops >> Progress",
+        title: "Display detailed drops information",
+        description: "Show more accurate drop information and progress.",
+        component: "setting-check-box"
+      },
+      changed: val => this.detailedDrops.handleSettingChange(val)
+    });
   }
 
   onEnable() {
     this.router.on(":route", this.navigate, this);
     this.autoClaimDrops.initialize();
     this.collapsibleDrops.initialize();
+    this.detailedDrops.initialize();
   }
 
   async navigate() {
     this.collapsibleDrops.handleNavigation();
+    this.detailedDrops.handleNavigation();
   }
 }

--- a/src/trubbel/settings/twilight/clips.js
+++ b/src/trubbel/settings/twilight/clips.js
@@ -1,4 +1,5 @@
 import ClipsSubdomain from "../../modules/twilight/clips/subdomain";
+import DownloadClips from "../../modules/channel/player/download-clips";
 
 export class Twilight_Clips extends FrankerFaceZ.utilities.module.Module {
   constructor(...args) {
@@ -8,8 +9,10 @@ export class Twilight_Clips extends FrankerFaceZ.utilities.module.Module {
     this.inject("site");
     this.inject("site.fine");
     this.inject("site.router");
+    this.inject("site.player");
 
     this.clipsSubdomain = new ClipsSubdomain(this);
+    this.downloadClips = new DownloadClips(this);
 
     // Twilight - Clips - Subdomain - Stay on clips subdomain
     this.settings.add("addon.trubbel.twilight.clips.subdomain", {
@@ -23,14 +26,29 @@ export class Twilight_Clips extends FrankerFaceZ.utilities.module.Module {
       },
       changed: val => this.clipsSubdomain.handleSettingChange(val)
     });
+
+
+
+    // Channel - Player - Clips - Download
+    this.settings.add("addon.trubbel.channel.player.clip.download", {
+      default: false,
+      ui: {
+        path: "Add-Ons > Trubbel\u2019s Utilities > Channel > Player >> Clips",
+        title: "Display Download Button on Clips",
+        component: "setting-check-box"
+      },
+      changed: val => this.downloadClips.handleSettingChange(val)
+    });
   }
 
   onEnable() {
     this.router.on(":route", this.navigate, this);
     this.clipsSubdomain.initialize();
+    this.downloadClips.initialize();
   }
 
   async navigate() {
     this.clipsSubdomain.handleNavigation();
+    this.downloadClips.handleNavigation();
   }
 }

--- a/src/trubbel/settings/twilight/experiments.js
+++ b/src/trubbel/settings/twilight/experiments.js
@@ -1,0 +1,62 @@
+import { EppoManager } from "../../modules/twilight/experiments/eppo";
+
+const { DEBUG } = FrankerFaceZ.utilities.constants;
+
+const EPPO = "addon.trubbel.eppo-exp-lock";
+
+export class Twilight_Experiments extends FrankerFaceZ.utilities.module.Module {
+  constructor(...args) {
+    super(...args);
+
+    this.inject("settings");
+    this.inject("site");
+
+    this.eppoManager = new EppoManager(this);
+
+    this.settings.addUI("addon.trubbel.twilight.experiments.eppo", {
+      path: "Add-Ons > Trubbel\u2019s Utilities > Overall > Experiments >> Eppo",
+      component: () => import("../../components/main_menu/experiments-eppo.vue"),
+      getExtraTerms: () => {
+        const values = [];
+        const flags = this.eppoManager.getEppoFlags();
+        if (!Object.keys(flags).length) return values;
+        for (const [key, flag] of Object.entries(flags)) {
+          values.push(key);
+          if (flag.variationType) values.push(flag.variationType);
+          if (flag.variations) {
+            for (const varKey of Object.keys(flag.variations)) {
+              values.push(varKey);
+            }
+          }
+        }
+        return values;
+      },
+      eppo_data: () => this.eppoManager.getEppoFlags(),
+      getAssignment: (key) => this.eppoManager.getAssignment(key),
+      hasOverride: (key) => this.eppoManager.hasOverride(key),
+      setOverride: (key, value) => this.eppoManager.setOverride(key, value),
+      deleteOverride: (key) => this.eppoManager.deleteOverride(key),
+      getVariationType: (key) => this.eppoManager.getVariationType(key),
+      is_locked: () => this.getControlsLocked(),
+      unlock: () => this.unlockControls(),
+      on: (...args) => this.on(...args),
+      off: (...args) => this.off(...args),
+    });
+  }
+
+  onEnable() {
+    this.eppoManager.initialize();
+  }
+
+  getControlsLocked() {
+    if (DEBUG) return false;
+
+    const ts = this.settings.provider.get(EPPO, 0);
+    if (isNaN(ts) || !isFinite(ts)) return true;
+    return Date.now() - ts >= 86400000;
+  }
+
+  unlockControls() {
+    this.settings.provider.set(EPPO, Date.now());
+  }
+}

--- a/src/trubbel/settings/twilight/icon-finder.js
+++ b/src/trubbel/settings/twilight/icon-finder.js
@@ -1,0 +1,223 @@
+function isUniquePattern(pattern, allSources) {
+  let count = 0;
+  for (const src of allSources) {
+    if (src.includes(pattern)) {
+      count++;
+      if (count > 1) return false;
+    }
+  }
+  return count === 1;
+}
+
+function getCenterOutIndices(length) {
+  const res = [];
+  const mid = Math.floor(length / 2);
+  res.push(mid);
+  for (let offset = 1; offset <= length; offset++) {
+    const left = mid - offset;
+    const right = mid + offset;
+    if (left >= 0) res.push(left);
+    if (right < length) res.push(right);
+    if (left < 0 && right >= length) break;
+  }
+  return res;
+}
+
+export function findSmallestUniquePattern(src, allSources, startLen = 20) {
+  for (let len = startLen; len <= src.length; len++) {
+    const possible = src.length - len + 1;
+    for (const i of getCenterOutIndices(possible)) {
+      const sub = src.substring(i, i + len);
+      if (isUniquePattern(sub, allSources))
+        return sub;
+    }
+  }
+  return src;
+}
+
+export function extractAllPaths(src) {
+  const paths = [];
+  const reD = /(?<![a-zA-Z])d:["']([^"']{5,})["']/g;
+  let m;
+  while ((m = reD.exec(src)) !== null)
+    paths.push({ d: m[1], type: "path" });
+
+  const rePoly = /points:["']([^"']{5,})["']/g;
+  while ((m = rePoly.exec(src)) !== null)
+    paths.push({ d: m[1], type: "polygon" });
+
+  return paths;
+}
+
+function isValidSvgShape(p) {
+  if (p.type === "polygon") return /\d/.test(p.d);
+  return /^[Mm]/.test(p.d) && /\d/.test(p.d);
+}
+
+function extractViewBox(factorySrc) {
+  const m = factorySrc.match(/viewBox:["']([^"']+)["']/)
+    || factorySrc.match(/viewBox="([^"]+)"/);
+  return m ? m[1] : "0 0 24 24";
+}
+
+function extractDisplayName(factorySrc) {
+  const m = factorySrc.match(/\.displayName\s*=\s*["']([^"']+)["']/);
+  return m ? m[1] : null;
+}
+
+export function buildSvgString(paths, { fill = "currentColor", size = 24, viewBox = "0 0 24 24" } = {}) {
+  const els = paths.map(p => {
+    if (p.type === "polygon")
+      return `<polygon points="${p.d}" fill="${fill}"/>`;
+    return `<path fill-rule="evenodd" clip-rule="evenodd" d="${p.d}" fill="${fill}"/>`;
+  }).join("");
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="${viewBox}" focusable="false" aria-hidden="true" role="presentation">${els}</svg>`;
+}
+
+const { createElement } = FrankerFaceZ.utilities.dom;
+
+import STYLE_URL from "../../components/main_menu/styles/icon-finder.scss";
+
+export class Twilight_IconFinder extends FrankerFaceZ.utilities.module.Module {
+  constructor(...args) {
+    super(...args);
+
+    this.inject("settings");
+    this.inject("site");
+    this.inject("site.web_munch");
+
+    this.settings.addUI("addon.trubbel.twilight.icon-finder", {
+      path: "Add-Ons > Trubbel\u2019s Utilities > Overall > Icon Finder >> Icon Finder @{\"profile_warning\": false}",
+      component: () => import("../../components/main_menu/icon-finder.vue"),
+      force_seen: true,
+
+      getIcons: () => this.getIcons(),
+      rescan: () => this.rescan(),
+      isScanning: () => this._scanning,
+      generateFind: (icon) => this.generateFind(icon),
+      getFFZ: () => this.resolve("core")
+    });
+
+    this._icons = null;
+    this._factorySources = null;
+    this._scanning = false;
+    this.style_link = null;
+  }
+
+  async onEnable() {
+    if (!this.style_link) {
+      document.head.appendChild(this.style_link = createElement("link", {
+        id: "trubbel-icon-finder",
+        "data-addon": "trubbel",
+        href: STYLE_URL,
+        rel: "stylesheet",
+        type: "text/css",
+        crossOrigin: "anonymous"
+      }));
+    }
+  }
+
+  getIcons() {
+    return this._icons ?? [];
+  }
+
+  rescan() {
+    this._icons = null;
+    this._factorySources = null;
+    return this.scanIcons();
+  }
+
+  scanIcons() {
+    this._scanning = true;
+    const require = this.web_munch._require;
+
+    if (!require?.m) {
+      this.log.warn("webpack require not available");
+      this._scanning = false;
+      return [];
+    }
+
+    const allModules = require.m;
+    const moduleIds = Object.keys(allModules);
+    this.log.info(`Scanning ${moduleIds.length} webpack modules…`);
+
+    let passed_prefilter = 0;
+    let rejected_no_paths = 0;
+    let required_count = 0;
+
+    const icons = [];
+    const factorySources = [];
+
+    for (const id of moduleIds) {
+      const factory = allModules[id];
+      if (typeof factory !== "function") continue;
+
+      const factorySrc = factory.toString();
+      if (!factorySrc.includes('viewBox:') && !factorySrc.includes('viewBox="') && !factorySrc.includes("viewBox='"))
+        continue;
+
+      passed_prefilter++;
+
+      const paths = extractAllPaths(factorySrc);
+      if (!paths.length || !paths.some(isValidSvgShape)) {
+        rejected_no_paths++;
+        continue;
+      }
+
+      const viewBox = extractViewBox(factorySrc);
+      const displayName = extractDisplayName(factorySrc);
+
+      let mod, component;
+      try {
+        mod = require(id);
+        required_count++;
+        component = mod?.default;
+        if (!component || (typeof component !== "function" && typeof component !== "object")) {
+          const vals = Object.values(mod ?? {});
+          component = vals.find(v => typeof v === "function" || (v && typeof v === "object" && v.$$typeof));
+        }
+      } catch(e) {
+        component = null;
+      }
+
+      factorySources.push(factorySrc);
+      icons.push({ id, factorySrc, paths, viewBox, displayName, component });
+    }
+
+    this.log.info(
+      `Scan complete: ${moduleIds.length} total, ` +
+      `${passed_prefilter} passed pre-filter, ` +
+      `${required_count} required, ` +
+      `${icons.length} icons found. ` +
+      `Rejections - no paths: ${rejected_no_paths}`
+    );
+
+    this._scanning = false;
+    this._icons = icons;
+    this._factorySources = factorySources;
+    return icons;
+  }
+
+  generateFind(icon) {
+    if (!this._icons?.length || !icon)
+      return "// No icons scanned yet";
+
+    const allFactorySources = this._factorySources ?? this._icons.map(i => i.factorySrc);
+    const pattern = findSmallestUniquePattern(icon.factorySrc, allFactorySources);
+    const escaped = JSON.stringify(pattern);
+
+    const name = icon.displayName ?? `Icon_${icon.id}`;
+
+    return `// ${name}
+      // Search by factory source - reliable even as class names change
+      const ${name} = (() => {
+        const req = this.web_munch._require;
+        for (const [id, factory] of Object.entries(req.m)) {
+          if (factory.toString().includes(${escaped})) {
+            const mod = req(id);
+            return mod?.default ?? Object.values(mod ?? {}).find(v => v && (typeof v === "function" || v.$$typeof));
+          }
+        }
+      })();`;
+  }
+}

--- a/src/trubbel/utilities/constants/config.js
+++ b/src/trubbel/utilities/constants/config.js
@@ -2,3 +2,4 @@ export const PRIME_REMINDER_KEY_CONFIG = "TrubbelPrimeReminder";
 export const COLLAPSIBLE_DROPS_KEY_CONFIG = "TrubbelCollapsibleDrops";
 export const WHISPER_HEIGHT_KEY_CONFIG = "TrubbelWhisperDropDownHeight";
 export const STOP_EMOTE_ANIM_KEY_CONFIG = "TrubbelStopEmoteAnimate";
+export const EPPO_OVERRIDES_KEY_CONFIG = "TrubbelEppoOverrides";

--- a/src/trubbel/utilities/graphql/download-clip.gql
+++ b/src/trubbel/utilities/graphql/download-clip.gql
@@ -1,0 +1,16 @@
+query Trubbel_DownloadClip($slug: ID!) {
+  clip(slug: $slug) {
+    id
+    title
+    thumbnailURL(width: 480, height: 272)
+    videoQualities {
+      frameRate
+      quality
+      sourceURL
+    }
+    playbackAccessToken(params: { platform: "web", playerType: "site" }) {
+      signature
+      value
+    }
+  }
+}


### PR DESCRIPTION
* Added: Automatically hide pinned messages
* Added: Disable click-to-pause on VODs
* Added: Display detailed drops information
* Added: Download Clip button
* Added: Eppo Experiments
* Added: Hide sponsored content in sidebar
* Added: Icon Finder
* Added: Prediction browser notification
* Added: Text Replace
* Fixed: Pinned Channels compatibility issues with FFZ setting "Display Recommended / Popular Channels"
* Changed: Animated emotes in blocklist now only animates on hover
* Changed: Raid previews now have separate options to display uptime and restrictions