### PR TITLE
Update 7TV 1 month badge ID

### DIFF
--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -14,5 +14,5 @@
 	"website": "https://7tv.app",
 	"settings": "add_ons.7tv_emotes",
 	"created": "2021-07-12T23:18:04.000Z",
-	"updated": "2026-04-20T16:32:37.628Z"
+	"updated": "2026-04-22T17:42:46.000Z"
 }

--- a/src/7tv-emotes/manifest.json
+++ b/src/7tv-emotes/manifest.json
@@ -5,7 +5,7 @@
 		"main",
 		"clips"
 	],
-	"version": "1.4.32",
+	"version": "1.4.33",
 	"short_name": "7TV",
 	"name": "7TV Emotes",
 	"author": "Melonify",

--- a/src/7tv-emotes/modules/badges.js
+++ b/src/7tv-emotes/modules/badges.js
@@ -24,12 +24,12 @@ export default class Badges extends FrankerFaceZ.utilities.module.Module {
 
 		// Load the "1 Month" subscriber badge so it can be hidden in FFZ without having to be seen first
 		this.addBadge({
-			id: '62f97c05e46eb00e438a696a',
+			id: '01GAF8RWW8000E8VNG1S1RMTBA',
 			name: '7TV Subscriber - 1 Month',
 			tag: 'sub1',
 			tooltip: '7TV Subscriber (1 Month)',
 			host: {
-				url: '//cdn.7tv.app/badge/62f97c05e46eb00e438a696a'
+				url: '//cdn.7tv.app/badge/01GAF8RWW8000E8VNG1S1RMTBA'
 			}
 		});
 	}


### PR DESCRIPTION
The old badge ID redirects to this one, and the old ID doesn't show up in the 7TV API when queried.

Thanks,
pointy