### PR TITLE
Disable Modchecker addon

### DIFF
--- a/src/modchecker/manifest.json
+++ b/src/modchecker/manifest.json
@@ -1,5 +1,5 @@
 {
-	"enabled": true,
+	"enabled": false,
 	"requires": [],
 	"version": "1.0",
 	"short_name": "Modchecker",


### PR DESCRIPTION
The website and the API are no longer working. I'd like to temporarily disable this add-on so as not to confuse people.