### PR TITLE
feat: upgrade twir addon to use v2 api endpoints

### DIFF
--- a/src/twir/api.js
+++ b/src/twir/api.js
@@ -23,15 +23,15 @@ export class Api extends FrankerFaceZ.utilities.module.Module {
 }
 
 export class Commands extends FrankerFaceZ.utilities.module.Module {
-	// https://twir.app/api/v1/public/channels/{userId}/commands
+	// https://twir.app/api/v2/public/channels/twitch/{userId}/commands
 	getChannelCommands(userId) {
-		return this.parent.request(`channels/${userId}/commands`);
+		return this.parent.request(`v2/public/channels/twitch/${userId}/commands`);
 	}
 }
 
 export class Badges extends FrankerFaceZ.utilities.module.Module {
 	// https://twir.app/api/v1/public/badges
 	getBadges() {
-		return this.parent.request('badges');
+		return this.parent.request('v1/public/badges');
 	}
 }

--- a/src/twir/api.js
+++ b/src/twir/api.js
@@ -5,7 +5,7 @@ export class Api extends FrankerFaceZ.utilities.module.Module {
 		this.inject(Commands);
 		this.inject(Badges);
 
-		this.apiBase = 'https://twir.app/api/v1/public';
+		this.apiBase = 'https://twir.app/api/';
 	}
 
 	async request(path) {

--- a/src/twir/manifest.json
+++ b/src/twir/manifest.json
@@ -1,7 +1,7 @@
 {
 	"enabled": true,
 	"requires": [],
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"short_name": "Twir",
 	"name": "Twir",
 	"author": "crashmax",


### PR DESCRIPTION
Updated:
- use v2 endpoint for channels commands, since v1 commands endpoint deprecated